### PR TITLE
Memory Leak Hotfix

### DIFF
--- a/Assets/Scripts/HUD/FileTabController.cs
+++ b/Assets/Scripts/HUD/FileTabController.cs
@@ -96,6 +96,7 @@ public class FileTabController : MonoBehaviour
     private IEnumerator _currentTimelineCoroutine;
     private IEnumerator _currentSubtitleCoroutine;
 
+    #region Controls Binding
     // move input actions
     private InputAction _upArrow;
     private InputAction _rightArrow;
@@ -106,30 +107,41 @@ public class FileTabController : MonoBehaviour
     {
         // bind input updating
         _upArrow = InputSystem.actions.FindAction("HUDUp");
-        _upArrow.started += context => FileInteraction();
+        _upArrow.started += DoFileInteraction;
         _upArrow.Enable();
         _rightArrow = InputSystem.actions.FindAction("HUDRight");
-        _rightArrow.started += context => FileInteraction();
+        _rightArrow.started += DoFileInteraction;
         _rightArrow.Enable();
         _downArrow = InputSystem.actions.FindAction("HUDDown");
-        _downArrow.started += context => FileInteraction();
+        _downArrow.started += DoFileInteraction;
         _downArrow.Enable();
         _leftArrow = InputSystem.actions.FindAction("HUDLeft");
-        _leftArrow.started += context => FileInteraction();
+        _leftArrow.started += DoFileInteraction;
         _leftArrow.Enable();
 
         TabOpen();
     }
+
     private void OnDisable()
     {
         // unbind input updating
-        _upArrow.started -= context => FileInteraction();
-        _rightArrow.started -= context => FileInteraction();
-        _downArrow.started -= context => FileInteraction();
-        _leftArrow.started -= context => FileInteraction();
+        _upArrow.started -= DoFileInteraction;
+        _rightArrow.started -= DoFileInteraction;
+        _downArrow.started -= DoFileInteraction;
+        _leftArrow.started -= DoFileInteraction;
 
         TabClose();
     }
+
+    /// <summary>
+    /// simply calls the FileInteraction function.
+    /// Necessary to avoid memory leak.
+    /// </summary>
+    private void DoFileInteraction(InputAction.CallbackContext context)
+    {
+        FileInteraction();
+    }
+    #endregion
 
     void Start()
     {

--- a/Assets/Scripts/HUD/HUDController.cs
+++ b/Assets/Scripts/HUD/HUDController.cs
@@ -24,17 +24,36 @@ public class HUDController : MonoBehaviour
 
     bool active = false;
 
+    #region Controls Bindings
     private void OnEnable()
     {
-        InputSystem.actions.FindAction("Tab").started += context => TabSwitch();
-        InputSystem.actions.FindAction("Tab").canceled += context => active = false;
+        InputSystem.actions.FindAction("Tab").started += DoTabSwitch;
+        InputSystem.actions.FindAction("Tab").canceled += SetActiveFalse;
     }
 
     private void OnDisable()
     {
-        InputSystem.actions.FindAction("Tab").started -= context => TabSwitch();
-        InputSystem.actions.FindAction("Tab").canceled -= context => active = false;
+        InputSystem.actions.FindAction("Tab").started -= DoTabSwitch;
+        InputSystem.actions.FindAction("Tab").canceled -= SetActiveFalse;
     }
+
+    /// <summary>
+    /// Simply calls TabSwitch() function.
+    /// Necessary to avoid memory leak
+    /// </summary>
+    private void DoTabSwitch(InputAction.CallbackContext context)
+    {
+        TabSwitch();
+    }
+
+    /// <summary>
+    /// Necessary to avoid memory leak.
+    /// </summary>
+    private void SetActiveFalse(InputAction.CallbackContext context)
+    {
+        active = false;
+    }
+    #endregion
 
     // Update is called once per frame
     void Update()

--- a/Assets/Scripts/HUD/Map Tab/KeycardDisplayController.cs
+++ b/Assets/Scripts/HUD/Map Tab/KeycardDisplayController.cs
@@ -28,6 +28,7 @@ public class KeycardDisplayController : MonoBehaviour
     private float _localKeyCount = 0;   // Used for seeing if there's a difference in GameManager & updating the visual here
     private int _currentIndex = 0;      // What key is currently selected
 
+    #region Controls Bindings
     // move input actions
     private InputAction _upArrow;
     private InputAction _rightArrow;
@@ -38,27 +39,37 @@ public class KeycardDisplayController : MonoBehaviour
     {
         // bind input updating
         _upArrow = InputSystem.actions.FindAction("HUDUp");
-        _upArrow.started += context => KeyInteraction();
+        _upArrow.started += DoKeyInteraction;
         _upArrow.Enable();
         _rightArrow = InputSystem.actions.FindAction("HUDRight");
-        _rightArrow.started += context => KeyInteraction();
+        _rightArrow.started += DoKeyInteraction;
         _rightArrow.Enable();
         _downArrow = InputSystem.actions.FindAction("HUDDown");
-        _downArrow.started += context => KeyInteraction();
+        _downArrow.started += DoKeyInteraction;
         _downArrow.Enable();
         _leftArrow = InputSystem.actions.FindAction("HUDLeft");
-        _leftArrow.started += context => KeyInteraction();
+        _leftArrow.started += DoKeyInteraction;
         _leftArrow.Enable();
     }
 
     private void OnDisable()
     {
         // unbind input updating
-        _upArrow.started -= context => KeyInteraction();
-        _rightArrow.started -= context => KeyInteraction();
-        _downArrow.started -= context => KeyInteraction();
-        _leftArrow.started -= context => KeyInteraction();
+        _upArrow.started -= DoKeyInteraction;
+        _rightArrow.started -= DoKeyInteraction;
+        _downArrow.started -= DoKeyInteraction;
+        _leftArrow.started -= DoKeyInteraction;
     }
+
+    /// <summary>
+    /// Simply calls KeyInteraction() function.
+    /// Necessary to avoid memory leak.
+    /// </summary>
+    private void DoKeyInteraction(InputAction.CallbackContext context)
+    {
+        KeyInteraction();
+    }
+    #endregion
 
     void Start()
     {

--- a/Assets/Scripts/HUD/Map Tab/MapTabController.cs
+++ b/Assets/Scripts/HUD/Map Tab/MapTabController.cs
@@ -44,16 +44,17 @@ public class MapTabController : MonoBehaviour
     private int _currentFloor;      // The floor the player is on
     private int _currentHUDFloor;   // The floor the HUD is displaying
 
+    // game manager vars
+    private int _visitationL1Length; // Kept because OnDisable tab cleanup calls the GameManager after it's destroyed
+    private int _visitationL2Length;
+    private int _visitationL3Length;
+
+    #region Controls Bindings
     // move input actions
     private InputAction _upArrow;
     private InputAction _rightArrow;
     private InputAction _downArrow;
     private InputAction _leftArrow;
-
-    // game manager vars
-    private int _visitationL1Length; // Kept because OnDisable tab cleanup calls the GameManager after it's destroyed
-    private int _visitationL2Length;
-    private int _visitationL3Length;
 
     private void OnEnable()
     {
@@ -61,16 +62,16 @@ public class MapTabController : MonoBehaviour
 
         // bind input updating
         _upArrow = InputSystem.actions.FindAction("HUDUp");
-        _upArrow.started += context => UpdateFloor();
+        _upArrow.started += DoUpdateFloor;
         _upArrow.Enable();
         _rightArrow = InputSystem.actions.FindAction("HUDRight");
-        _rightArrow.started += context => UpdateFloor();
+        _rightArrow.started += DoUpdateFloor;
         _rightArrow.Enable();
         _downArrow = InputSystem.actions.FindAction("HUDDown");
-        _downArrow.started += context => UpdateFloor();
+        _downArrow.started += DoUpdateFloor;
         _downArrow.Enable();
         _leftArrow = InputSystem.actions.FindAction("HUDLeft");
-        _leftArrow.started += context => UpdateFloor();
+        _leftArrow.started += DoUpdateFloor;
         _leftArrow.Enable();
     }
 
@@ -80,10 +81,20 @@ public class MapTabController : MonoBehaviour
 
         // unbind input updating
         _upArrow.started -= context => UpdateFloor();
-        _rightArrow.started -= context => UpdateFloor();
-        _downArrow.started -= context => UpdateFloor();
-        _leftArrow.started -= context => UpdateFloor();
+        _rightArrow.started -= DoUpdateFloor;
+        _downArrow.started -= DoUpdateFloor;
+        _leftArrow.started -= DoUpdateFloor;
     }
+
+    /// <summary>
+    /// Simply calls UpdateFloor function.
+    /// Necessary to avoid memory leak.
+    /// </summary>
+    private void DoUpdateFloor(InputAction.CallbackContext context)
+    {
+        UpdateFloor();
+    }
+    #endregion
 
     void Start()
     {

--- a/Assets/Scripts/Interaction/PlayerInteractor.cs
+++ b/Assets/Scripts/Interaction/PlayerInteractor.cs
@@ -15,16 +15,26 @@ public class PlayerInteractor : MonoBehaviour
 
     // Player Interactor: Checks for if the player is in radius of an interactable
 
+    #region Controls Bindings
     private void OnEnable()
     {
-        InputSystem.actions.FindAction("Interact").started += context => Interact(); 
+        InputSystem.actions.FindAction("Interact").started += DoInteract; 
     }
 
     private void OnDisable()
     {
-        InputSystem.actions.FindAction("Interact").started -= context => Interact();
+        InputSystem.actions.FindAction("Interact").started -= DoInteract;
     }
 
+    /// <summary>
+    /// Simply calls Interact() function.
+    /// Necessary to avoid memory leak.
+    /// </summary>
+    private void DoInteract(InputAction.CallbackContext context)
+    {
+        Interact();
+    }
+    #endregion
 
     // Start is called before the first frame update
     void Start()


### PR DESCRIPTION
# Memory Leak Hotfix - PR
Please merge the **Controls Remapping PR** BEFORE this one.

Properly assigns & unassigns input listener references in the following places:
- HUD tab swapping
- File tab controls
- Map tab floor navigation
- Map tab keycard navigation
- Player interactions

Although I tried - I was not able to guarantee that this is the source of the memory issues. Regardless, this fix was needed for other crash reasons.