### PR TITLE
Misc. Polish 3

### DIFF
--- a/Assets/Prefabs/Micro Puzzles/Wire Box/Wire Selectors/Wire Selector.prefab
+++ b/Assets/Prefabs/Micro Puzzles/Wire Box/Wire Selectors/Wire Selector.prefab
@@ -56,6 +56,7 @@ MonoBehaviour:
   StuckTape: {fileID: 0}
   UnstuckTape: {fileID: 0}
   WireRenderer: {fileID: 0}
+  _coll: {fileID: 3053649900394042251}
 --- !u!136 &3053649900394042251
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -424,6 +425,10 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 5aece0cafe7f3564eb0c1d6112463d20, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -5992887968803144492, guid: 5aece0cafe7f3564eb0c1d6112463d20, type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -5992887968803144492, guid: 5aece0cafe7f3564eb0c1d6112463d20, type: 3}
       propertyPath: m_Materials.Array.data[0]

--- a/Assets/Prefabs/ModularPrefabs/Decor/Medical/Bed Hospital.prefab
+++ b/Assets/Prefabs/ModularPrefabs/Decor/Medical/Bed Hospital.prefab
@@ -84,8 +84,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 2.7436557, y: 0.87782764, z: 1.2715453}
-  m_Center: {x: -0.14956278, y: 0.47745562, z: 0}
+  m_Size: {x: 2.660243, y: 0.87782764, z: 1.209232}
+  m_Center: {x: -0.17747998, y: 0.47745562, z: 0.004146397}
 --- !u!65 &1854327075428763084
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -105,8 +105,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 0.2977404, y: 1.814636, z: 1.8489633}
-  m_Center: {x: -0.3511298, y: 1.3486751, z: -0.007509619}
+  m_Size: {x: 0.2977404, y: 1.814636, z: 1.9310565}
+  m_Center: {x: -0.3511298, y: 1.3486751, z: 0.006546855}
 --- !u!1001 &8559000404624063341
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ModularPrefabs/Decor/Medical/Hanging Med Bags.prefab
+++ b/Assets/Prefabs/ModularPrefabs/Decor/Medical/Hanging Med Bags.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4511929182020852995}
   - component: {fileID: 6152659048445826356}
-  - component: {fileID: 8996277923979676118}
+  - component: {fileID: 5896948856683226156}
   m_Layer: 0
   m_Name: Hanging Med Bags
   m_TagString: Untagged
@@ -64,8 +64,8 @@ LODGroup:
     - renderer: {fileID: 4360463337841234609}
     - renderer: {fileID: 4588446855501455983}
   m_Enabled: 1
---- !u!65 &8996277923979676118
-BoxCollider:
+--- !u!136 &5896948856683226156
+CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -82,9 +82,11 @@ BoxCollider:
   m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.5, y: 1.9948957, z: 0.5}
-  m_Center: {x: 0, y: 1.0242444, z: 0}
+  serializedVersion: 2
+  m_Radius: 0.17853874
+  m_Height: 2.4432843
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.9708971, z: 0}
 --- !u!1001 &3831379204433700058
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ModularPrefabs/Decor/Multi Room (misc)/Arm Chair.prefab
+++ b/Assets/Prefabs/ModularPrefabs/Decor/Multi Room (misc)/Arm Chair.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 7099466015444382356}
   - component: {fileID: 6851852198253854440}
   - component: {fileID: -4091859955102044262}
+  - component: {fileID: 6871589192105215330}
   m_Layer: 0
   m_Name: Arm Chair
   m_TagString: Untagged
@@ -53,8 +54,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1.29, y: 0.79999995, z: 0.7931646}
-  m_Center: {x: 0, y: 0.39, z: -0.0150450915}
+  m_Size: {x: 1.2847933, y: 0.68731767, z: 0.5315102}
+  m_Center: {x: -0.000000022494216, y: 0.33365884, z: -0.06894841}
 --- !u!205 &-4091859955102044262
 LODGroup:
   m_ObjectHideFlags: 0
@@ -76,6 +77,27 @@ LODGroup:
     - renderer: {fileID: 8991512674727199685}
     - renderer: {fileID: 1484681402761904634}
   m_Enabled: 1
+--- !u!65 &6871589192105215330
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4711608868017140596}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.2518595, y: 0.98247534, z: 0.20268537}
+  m_Center: {x: 0.000000028578345, y: 0.67416656, z: 0.25547642}
 --- !u!1001 &876280747231555273
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ModularPrefabs/Decor/Multi Room (misc)/Remote.prefab
+++ b/Assets/Prefabs/ModularPrefabs/Decor/Multi Room (misc)/Remote.prefab
@@ -70,6 +70,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 2092c78a453df6543b273bcf65e7ce85, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2092c78a453df6543b273bcf65e7ce85, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2092c78a453df6543b273bcf65e7ce85, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2092c78a453df6543b273bcf65e7ce85, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}
@@ -108,6 +120,10 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 2092c78a453df6543b273bcf65e7ce85, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2092c78a453df6543b273bcf65e7ce85, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8256134651489076907, guid: 2092c78a453df6543b273bcf65e7ce85, type: 3}
       propertyPath: m_StaticEditorFlags

--- a/Assets/Prefabs/ModularPrefabs/Decor/Multi Room (misc)/Television.prefab
+++ b/Assets/Prefabs/ModularPrefabs/Decor/Multi Room (misc)/Television.prefab
@@ -138,6 +138,10 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 2147483647
       objectReference: {fileID: 0}
+    - target: {fileID: -1526509560930016547, guid: 4f652587f1bb4a946a6b9bdf29978f77, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: c0a6daab2b027dc40b3d38e99275d319, type: 2}
     - target: {fileID: 635547659545568360, guid: 4f652587f1bb4a946a6b9bdf29978f77, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 2147483647

--- a/Assets/Prefabs/ModularPrefabs/Interaction Objects/DumbWaiter.prefab
+++ b/Assets/Prefabs/ModularPrefabs/Interaction Objects/DumbWaiter.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 3829800995935570233}
   - component: {fileID: -3738942992436567439}
   - component: {fileID: 4011626027639830714}
+  - component: {fileID: 3012466410594907313}
   m_Layer: 0
   m_Name: DumbWaiter
   m_TagString: Untagged
@@ -78,6 +79,27 @@ MonoBehaviour:
   _openDistance: 2.75
   _anim: {fileID: 2860583662184932487}
   _audio: {fileID: 5838824635180673391}
+--- !u!65 &3012466410594907313
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2126547428343602706}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.6093271, y: 3, z: 0.3}
+  m_Center: {x: 0, y: 1.5, z: 0}
 --- !u!1001 &2857376184173098632
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Micro Puzzles/WireBox/ConnectionRemover.cs
+++ b/Assets/Scripts/Micro Puzzles/WireBox/ConnectionRemover.cs
@@ -40,9 +40,7 @@ public class ConnectionRemover : ClickableObject
     public override void OnObjectClick()
     {
         // re-enable wire on wire board
-        _wireSelector.gameObject.SetActive(true);
-        _wireSelector.StuckTape.SetActive(true);
-        _wireSelector.UnstuckTape.SetActive(false);
+        _wireSelector.ReturnWire();
 
         // remove node connections for connection processing
         _connectedNodes[0].RemoveConnection(_connectedNodes[1]);

--- a/Assets/Scripts/Micro Puzzles/WireBox/WireManager.cs
+++ b/Assets/Scripts/Micro Puzzles/WireBox/WireManager.cs
@@ -56,9 +56,7 @@ public class WireManager : MonoBehaviour
     public void ConsumeCurrentWire()
     {
         _currWire.DeselectVisual();
-        _currWire.gameObject.SetActive(false);
-        _currWire.StuckTape.SetActive(false);
-        _currWire.UnstuckTape.SetActive(true);
+        _currWire.RemoveWire();
         _currWire = null;
     }
 }

--- a/Assets/Scripts/Micro Puzzles/WireBox/WireSelector.cs
+++ b/Assets/Scripts/Micro Puzzles/WireBox/WireSelector.cs
@@ -25,6 +25,8 @@ public class WireSelector : ClickableObject
     public GameObject UnstuckTape;
     [SerializeField, Tooltip("Main wire renderer for fetching material to be placed on newly placed wire.")]
     public Renderer WireRenderer;
+    [SerializeField, Tooltip("Used to disable wire functionality even though object still enabled.")]
+    private Collider _coll;
 
     private WireManager _wireManager;
     private Outline _outline;
@@ -81,6 +83,28 @@ public class WireSelector : ClickableObject
         _outline.OutlineWidth = _outlineWidth;
         _outline.OutlineColor = _selectedColor;
         _isSelected = true;
+    }
+
+    /// <summary>
+    /// Removes wire visual and collider functionality from left board.
+    /// </summary>
+    public void RemoveWire()
+    {
+        _coll.enabled = false;
+        WireRenderer.enabled = false;
+        StuckTape.SetActive(false);
+        UnstuckTape.SetActive(true);
+    }
+
+    /// <summary>
+    /// Returns wire to left board.
+    /// </summary>
+    public void ReturnWire()
+    {
+        _coll.enabled = true;
+        WireRenderer.enabled = true;
+        StuckTape.SetActive(true);
+        UnstuckTape.SetActive(false);
     }
 
     public override void OnObjectHover()


### PR DESCRIPTION
# Misc. Polish 3 - PR
Mainly floor 2 stuff, with the biggest changes being to creature zones! Should be a relatively swift review as I didn't actually touch much outside of Floor2. This is seriously coming together :)
## Misc. Fixes
- unstuck tape models now show again in wire box when a wire is placed (without changing actual disable functionality)
- Dumbwaiter now has collider so you can't walk out of the world through them
- adjusted colliders to better fit models: Arm Chair, Hanging Med Bags, and Bed Hospital
## Floor 2 - General
- all wire boxes now have connector bar between box & door
- all wire boxes equally indented into the wall
- adjusted wire placements in boxes to not overlap help stickies
- adjusted desk & lighting placement in offices to better fit wire box puzzle
- added Command keycard to Orchard
- added DoNotDisturbBypass keycard to Rec Center
- pulled living hub bathroom lights more into bathroom entrances to prevent hall light from making residential lobby area effectively never dark (felt wrong for creature spawning basically in light)
## Floor 2 - Creature Zones
- Residential Creature Zone Tweaks:
  - aligned with new hallway location
  - better suited to potential first creature encounter
  - aggro bypassed entirely by sneaking through by couches
  - if aggroed, very easy to return to living hub or run to terminal glow
  - still spawns at end of left residential hallway to basically block player from doing much here if entering from rec center
- Offices Creature Zone Tweaks:
  - better suited as potential first creature encounter
  - creature spawns farther away to allow player to experiment with aggro / creature behavior more easily
  - player can easily get to terminal without any creature aggro
- Farm Creature Zone Tweaks:
  - added cart obstructions to prevent going straight to the exit door
  - creature spawns in wheat field, with aggro activating soon after turning left from dumbwaiter entrance spot
  - relatively straightforward without stun needed, with optional through crops shortcuts
- Medical Creature Zone Tweaks:
  - moved terminal to back side of desk area to prevent creature from walking through light
  - creature now spawns in center desk area (keycard also is there)
  - player basically enters hall and must go around desk quickly (either side)
- New Communal Creature Zones:
  - includes three small sub-zones: Kitchen, Bathroom, Rec Center
  - each zone is basically a 'you can't do anything here' creature zone, with bathroom and rec center being roughly placed to also block keycards
  - intended to just make player want to solve terminal for light