### PR TITLE
Prebuild lighting - PR

### DIFF
--- a/Assets/Prefabs/ModularPrefabs/Rooms/Bedroom.prefab
+++ b/Assets/Prefabs/ModularPrefabs/Rooms/Bedroom.prefab
@@ -2698,7 +2698,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7624977249002281496, guid: a4a0895fc60d28549b0ed34b9bdef19e, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -2897,6 +2897,10 @@ PrefabInstance:
     - target: {fileID: 2472542620385324464, guid: a4a0895fc60d28549b0ed34b9bdef19e, type: 3}
       propertyPath: m_Name
       value: Bed
+      objectReference: {fileID: 0}
+    - target: {fileID: 3795495451382433846, guid: a4a0895fc60d28549b0ed34b9bdef19e, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -3294,6 +3298,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Bed
       objectReference: {fileID: 0}
+    - target: {fileID: 3795495451382433846, guid: a4a0895fc60d28549b0ed34b9bdef19e, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -3426,6 +3434,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Bed (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 7624977249002281496, guid: a4a0895fc60d28549b0ed34b9bdef19e, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -3557,6 +3569,10 @@ PrefabInstance:
     - target: {fileID: 2472542620385324464, guid: a4a0895fc60d28549b0ed34b9bdef19e, type: 3}
       propertyPath: m_Name
       value: Bed (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3795495451382433846, guid: a4a0895fc60d28549b0ed34b9bdef19e, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -7622,6 +7638,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Bed (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 7624977249002281496, guid: a4a0895fc60d28549b0ed34b9bdef19e, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -7885,6 +7905,10 @@ PrefabInstance:
     - target: {fileID: 2472542620385324464, guid: a4a0895fc60d28549b0ed34b9bdef19e, type: 3}
       propertyPath: m_Name
       value: Bed
+      objectReference: {fileID: 0}
+    - target: {fileID: 3795495451382433846, guid: a4a0895fc60d28549b0ed34b9bdef19e, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7624977249002281496, guid: a4a0895fc60d28549b0ed34b9bdef19e, type: 3}
       propertyPath: m_IsActive

--- a/Assets/Scenes/Floor1_Temp.unity.meta
+++ b/Assets/Scenes/Floor1_Temp.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6aa476205c7005a4dab89279a61cdda5
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Floor1_Temp.unity.meta
+++ b/Assets/Scenes/Floor1_Temp.unity.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 6aa476205c7005a4dab89279a61cdda5
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scenes/Floor2_Temp.unity.meta
+++ b/Assets/Scenes/Floor2_Temp.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 535113a99b746054ab3fc0128dc3db9a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Floor2_Temp.unity.meta
+++ b/Assets/Scenes/Floor2_Temp.unity.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 535113a99b746054ab3fc0128dc3db9a
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/FarmOrchard.mat
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/FarmOrchard.mat
@@ -1,0 +1,92 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: FarmOrchard
+  m_Shader: {fileID: -6465566751694194690, guid: b1fa5357fcf0be5488143117fec2f45b, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _Normals_Texture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Side2Texture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SideTexture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Texture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TopTexture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BUILTIN_QueueControl: 0
+    - _BUILTIN_QueueOffset: 0
+    - _BaseMaterialRoughness: 0.58
+    - _BaseRoughness: 0.06
+    - _MetallicBase: 0.18
+    - _MetallicIntensity: 1
+    - _MetallicNoise: 0.39
+    - _Noise1Seed: 18.22
+    - _Noise1_Intensity: 0.02
+    - _Noise2Seed: 14.6
+    - _Noise2_Intensity: 0.02
+    - _Noise3Intensity: -0.04
+    - _Noise3Seed: 3.83
+    - _NoiseNormals: 0
+    - _NoiseRoughness: 0.54
+    - _NoiseRoughnessIntensity: 1
+    - _Noise_Normals_On: 0
+    - _Normal_Texture_On: 0
+    - _NormalsIntensity: 0
+    - _OveralNoiseIntensity: 1.36
+    - _OverallNoiseScale: 0
+    - _OverallNoiseScale_1: 41.4
+    - _Scale: 1
+    - _Smoothnness: 41.4
+    - _TextureNormalIntensity: 1
+    - _TextureTiling: 0.75
+    - _Transitions: 0.5
+    - _TriPlaneBlur: 0.5
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 0.2627451}
+    - _Transition: {r: 32, g: 32, b: 32, a: 0}
+  m_BuildTextureStacks: []
+--- !u!114 &2119745265945795886
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/FarmOrchard.mat.meta
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/FarmOrchard.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b4d10bfacfe3fb94face0b2fb9ecadb6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/Kitchen.mat
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/Kitchen.mat
@@ -1,0 +1,91 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Kitchen
+  m_Shader: {fileID: -6465566751694194690, guid: b1fa5357fcf0be5488143117fec2f45b, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _Normals_Texture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Side2Texture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SideTexture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Texture:
+        m_Texture: {fileID: 2800000, guid: e7749257878410f4a8938c2d8f2a3c41, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TopTexture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BUILTIN_QueueControl: 0
+    - _BUILTIN_QueueOffset: 0
+    - _BaseMaterialRoughness: 0.58
+    - _BaseRoughness: 0.06
+    - _MetallicBase: 0.18
+    - _MetallicIntensity: 1
+    - _MetallicNoise: 0.39
+    - _Noise1Seed: 18.22
+    - _Noise1_Intensity: 0.02
+    - _Noise2Seed: 14.6
+    - _Noise2_Intensity: 0.02
+    - _Noise3Intensity: -0.04
+    - _Noise3Seed: 3.83
+    - _NoiseNormals: 0
+    - _NoiseRoughness: 0.54
+    - _NoiseRoughnessIntensity: 1
+    - _Noise_Normals_On: 0
+    - _Normal_Texture_On: 0
+    - _NormalsIntensity: 0
+    - _OveralNoiseIntensity: 1.36
+    - _OverallNoiseScale: 0
+    - _OverallNoiseScale_1: 41.4
+    - _Scale: 1
+    - _Smoothnness: 41.4
+    - _TextureTiling: 0.5
+    - _Transitions: 0.5
+    - _TriPlaneBlur: 0.5
+    m_Colors:
+    - _BaseColor: {r: 0.44, g: 0.44, b: 0.44, a: 0.2627451}
+    - _Transition: {r: 32, g: 32, b: 32, a: 0}
+  m_BuildTextureStacks: []
+--- !u!114 &2119745265945795886
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/Kitchen.mat.meta
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/Kitchen.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9ed8673c65c3d01498e0ccdc11d0a682
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/MedicalTile.mat
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/MedicalTile.mat
@@ -1,0 +1,91 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: MedicalTile
+  m_Shader: {fileID: -6465566751694194690, guid: b1fa5357fcf0be5488143117fec2f45b, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _Normals_Texture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Side2Texture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SideTexture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Texture:
+        m_Texture: {fileID: 2800000, guid: e7749257878410f4a8938c2d8f2a3c41, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TopTexture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BUILTIN_QueueControl: 0
+    - _BUILTIN_QueueOffset: 0
+    - _BaseMaterialRoughness: 0.58
+    - _BaseRoughness: 0.7
+    - _MetallicBase: 0.1
+    - _MetallicIntensity: 1
+    - _MetallicNoise: 0.1
+    - _Noise1Seed: 16.3
+    - _Noise1_Intensity: 0.02
+    - _Noise2Seed: 7.7
+    - _Noise2_Intensity: 0.02
+    - _Noise3Intensity: -0.04
+    - _Noise3Seed: 10.31
+    - _NoiseNormals: 0
+    - _NoiseRoughness: 0.7
+    - _NoiseRoughnessIntensity: 1
+    - _Noise_Normals_On: 0
+    - _Normal_Texture_On: 0
+    - _NormalsIntensity: 0
+    - _OveralNoiseIntensity: 0.5
+    - _OverallNoiseScale: 0
+    - _OverallNoiseScale_1: 41.4
+    - _Scale: 1
+    - _Smoothnness: 41.4
+    - _TextureTiling: 1.5
+    - _Transitions: 0.5
+    - _TriPlaneBlur: 32
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Transition: {r: 32, g: 32, b: 32, a: 0}
+  m_BuildTextureStacks: []
+--- !u!114 &2119745265945795886
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/MedicalTile.mat.meta
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/MedicalTile.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cd8b543ed3beb5a4cba24079abafeeaf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/Offices.mat
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/Offices.mat
@@ -1,0 +1,84 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Offices
+  m_Shader: {fileID: -6465566751694194690, guid: b1fa5357fcf0be5488143117fec2f45b, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _Normals_Texture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Side2Texture:
+        m_Texture: {fileID: 2800000, guid: e34091010bb66964785a1ab88962b936, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SideTexture:
+        m_Texture: {fileID: 2800000, guid: e34091010bb66964785a1ab88962b936, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TopTexture:
+        m_Texture: {fileID: 2800000, guid: 98f7610c62e960141a0669afc6534752, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BUILTIN_QueueControl: 0
+    - _BUILTIN_QueueOffset: 0
+    - _BaseMaterialRoughness: 0.58
+    - _BaseRoughness: 0
+    - _MetallicBase: 0
+    - _MetallicIntensity: 1
+    - _MetallicNoise: 0
+    - _Noise1Seed: 16.3
+    - _Noise1_Intensity: 0.02
+    - _Noise2Seed: 7.7
+    - _Noise2_Intensity: 0.02
+    - _Noise3Intensity: -0.04
+    - _Noise3Seed: -2.3
+    - _NoiseNormals: 0
+    - _NoiseRoughness: 0
+    - _NoiseRoughnessIntensity: 1
+    - _Noise_Normals_On: 0
+    - _Normal_Texture_On: 0
+    - _NormalsIntensity: 0
+    - _OveralNoiseIntensity: 2.26
+    - _OverallNoiseScale: 0
+    - _Scale: 1
+    - _Smoothnness: 269.18
+    - _Transitions: 0.5
+    m_Colors:
+    - _BaseColor: {r: 0.24993727, g: 0.33962262, b: 0.23869704, a: 0}
+    - _Transition: {r: 32, g: 32, b: 32, a: 0}
+  m_BuildTextureStacks: []
+--- !u!114 &2119745265945795886
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/Offices.mat.meta
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/Offices.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 23561c3fd39904c489a11fa2295af53e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/Rec Center.mat
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/Rec Center.mat
@@ -74,7 +74,7 @@ Material:
     - _Transitions: 0.5
     - _TriPlaneBlur: 32
     m_Colors:
-    - _BaseColor: {r: 0.5566038, g: 0.30952397, b: 0.05513528, a: 0}
+    - _BaseColor: {r: 0.24993727, g: 0.33962262, b: 0.23869704, a: 0}
     - _Transition: {r: 32, g: 32, b: 32, a: 0}
   m_BuildTextureStacks: []
 --- !u!114 &2119745265945795886

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/Rec Center.mat
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/Rec Center.mat
@@ -1,0 +1,92 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Rec Center
+  m_Shader: {fileID: -6465566751694194690, guid: b1fa5357fcf0be5488143117fec2f45b, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _Normals_Texture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Side2Texture:
+        m_Texture: {fileID: 2800000, guid: e34091010bb66964785a1ab88962b936, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SideTexture:
+        m_Texture: {fileID: 2800000, guid: e34091010bb66964785a1ab88962b936, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Texture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TopTexture:
+        m_Texture: {fileID: 2800000, guid: 98f7610c62e960141a0669afc6534752, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BUILTIN_QueueControl: 0
+    - _BUILTIN_QueueOffset: 0
+    - _BaseMaterialRoughness: 0.58
+    - _BaseRoughness: 0
+    - _MetallicBase: 0
+    - _MetallicIntensity: 1
+    - _MetallicNoise: 0
+    - _Noise1Seed: 16.3
+    - _Noise1_Intensity: 0.02
+    - _Noise2Seed: 7.7
+    - _Noise2_Intensity: 0.02
+    - _Noise3Intensity: -0.04
+    - _Noise3Seed: -2.3
+    - _NoiseNormals: 0
+    - _NoiseRoughness: 0
+    - _NoiseRoughnessIntensity: 1
+    - _Noise_Normals_On: 0
+    - _Normal_Texture_On: 0
+    - _NormalsIntensity: 0
+    - _OveralNoiseIntensity: 2.26
+    - _OverallNoiseScale: 0
+    - _OverallNoiseScale_1: 41.4
+    - _Scale: 1
+    - _Smoothnness: 269.18
+    - _TextureNormalIntensity: 1
+    - _TextureTiling: 1
+    - _Transitions: 0.5
+    - _TriPlaneBlur: 32
+    m_Colors:
+    - _BaseColor: {r: 0.5566038, g: 0.30952397, b: 0.05513528, a: 0}
+    - _Transition: {r: 32, g: 32, b: 32, a: 0}
+  m_BuildTextureStacks: []
+--- !u!114 &2119745265945795886
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/Rec Center.mat.meta
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/Rec Center.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cfc71cf2b59ceff429c9e35f18c82454
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/Residental Office.mat
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/Residental Office.mat
@@ -1,0 +1,84 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Residental Office
+  m_Shader: {fileID: -6465566751694194690, guid: b1fa5357fcf0be5488143117fec2f45b, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _Normals_Texture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Side2Texture:
+        m_Texture: {fileID: 2800000, guid: e34091010bb66964785a1ab88962b936, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SideTexture:
+        m_Texture: {fileID: 2800000, guid: e34091010bb66964785a1ab88962b936, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TopTexture:
+        m_Texture: {fileID: 2800000, guid: 98f7610c62e960141a0669afc6534752, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BUILTIN_QueueControl: 0
+    - _BUILTIN_QueueOffset: 0
+    - _BaseMaterialRoughness: 0.58
+    - _BaseRoughness: 0
+    - _MetallicBase: 0
+    - _MetallicIntensity: 1
+    - _MetallicNoise: 0
+    - _Noise1Seed: 16.3
+    - _Noise1_Intensity: 0.02
+    - _Noise2Seed: 7.7
+    - _Noise2_Intensity: 0.02
+    - _Noise3Intensity: -0.04
+    - _Noise3Seed: -2.3
+    - _NoiseNormals: 0
+    - _NoiseRoughness: 0
+    - _NoiseRoughnessIntensity: 1
+    - _Noise_Normals_On: 0
+    - _Normal_Texture_On: 0
+    - _NormalsIntensity: 0
+    - _OveralNoiseIntensity: 2.26
+    - _OverallNoiseScale: 0
+    - _Scale: 1
+    - _Smoothnness: 269.18
+    - _Transitions: 0.5
+    m_Colors:
+    - _BaseColor: {r: 0.24993727, g: 0.33962262, b: 0.23869704, a: 0}
+    - _Transition: {r: 32, g: 32, b: 32, a: 0}
+  m_BuildTextureStacks: []
+--- !u!114 &2119745265945795886
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/Residental Office.mat.meta
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/Residental Office.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e549fe62293e80043aaf6ba5a491b695
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/Residental.mat
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/Residental.mat
@@ -1,0 +1,91 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Residental
+  m_Shader: {fileID: -6465566751694194690, guid: b1fa5357fcf0be5488143117fec2f45b, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _Normals_Texture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Side2Texture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SideTexture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Texture:
+        m_Texture: {fileID: 2800000, guid: 1d1f09ba0d03a524f9fe684fe30843c7, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TopTexture:
+        m_Texture: {fileID: 2800000, guid: 901184bafbb11c44bbe787ab87254c6d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BUILTIN_QueueControl: 0
+    - _BUILTIN_QueueOffset: 0
+    - _BaseMaterialRoughness: 0.58
+    - _BaseRoughness: 0.06
+    - _MetallicBase: 0.18
+    - _MetallicIntensity: 1
+    - _MetallicNoise: 0.39
+    - _Noise1Seed: 18.22
+    - _Noise1_Intensity: 0.02
+    - _Noise2Seed: 14.6
+    - _Noise2_Intensity: 0.02
+    - _Noise3Intensity: -0.04
+    - _Noise3Seed: 3.83
+    - _NoiseNormals: 0
+    - _NoiseRoughness: 0.54
+    - _NoiseRoughnessIntensity: 1
+    - _Noise_Normals_On: 0
+    - _Normal_Texture_On: 0
+    - _NormalsIntensity: 0
+    - _OveralNoiseIntensity: 1.36
+    - _OverallNoiseScale: 0
+    - _OverallNoiseScale_1: 41.4
+    - _Scale: 1
+    - _Smoothnness: 41.4
+    - _TextureTiling: 0.75
+    - _Transitions: 0.5
+    - _TriPlaneBlur: 0.5
+    m_Colors:
+    - _BaseColor: {r: 0.2924528, g: 0.15944974, b: 0.051041294, a: 0.2627451}
+    - _Transition: {r: 32, g: 32, b: 32, a: 0}
+  m_BuildTextureStacks: []
+--- !u!114 &2119745265945795886
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/Residental.mat.meta
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/Residental.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d6cb1eab3386d614ba67c1c7be93e2af
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders & Materials/Primary Lighting.lighting
+++ b/Assets/Shaders & Materials/Primary Lighting.lighting
@@ -18,7 +18,7 @@ LightingSettings:
   m_UsingShadowmask: 1
   m_BakeBackend: 2
   m_LightmapMaxSize: 2048
-  m_BakeResolution: 30
+  m_BakeResolution: 10
   m_Padding: 10
   m_LightmapCompression: 3
   m_AO: 0

--- a/Assets/Shaders & Materials/Primary Lighting.lighting
+++ b/Assets/Shaders & Materials/Primary Lighting.lighting
@@ -18,8 +18,8 @@ LightingSettings:
   m_UsingShadowmask: 1
   m_BakeBackend: 2
   m_LightmapMaxSize: 2048
-  m_BakeResolution: 10
-  m_Padding: 10
+  m_BakeResolution: 15
+  m_Padding: 15
   m_LightmapCompression: 3
   m_AO: 0
   m_AOMaxDistance: 1

--- a/Assets/Shaders & Materials/Shaders/Shadow VFX_Shader.shadergraph
+++ b/Assets/Shaders & Materials/Shaders/Shadow VFX_Shader.shadergraph
@@ -206,6 +206,18 @@
         },
         {
             "m_Id": "52eaa389f08d4a36a613b68aa4a1450a"
+        },
+        {
+            "m_Id": "d672567a79f1407193e7832652303b2d"
+        },
+        {
+            "m_Id": "9879830bdf834b798c92ff56fb0f5368"
+        },
+        {
+            "m_Id": "87f567242ed74d54ba4bfaa2abc4dd2d"
+        },
+        {
+            "m_Id": "640693e4305f416393cdf739afa9f875"
         }
     ],
     "m_GroupDatas": [],
@@ -276,7 +288,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "57f0403739444d20b54d3f6652a771be"
+                    "m_Id": "640693e4305f416393cdf739afa9f875"
                 },
                 "m_SlotId": 0
             }
@@ -416,7 +428,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "373939c6fdbb4ca093087071959471a6"
+                    "m_Id": "d672567a79f1407193e7832652303b2d"
                 },
                 "m_SlotId": 0
             }
@@ -444,7 +456,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "8867b250b3a44b7eab8b6bfd474fa78f"
+                    "m_Id": "87f567242ed74d54ba4bfaa2abc4dd2d"
                 },
                 "m_SlotId": 0
             }
@@ -473,6 +485,20 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "3e27dc874d694ab6b4a899774499823c"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "640693e4305f416393cdf739afa9f875"
+                },
+                "m_SlotId": 3
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "57f0403739444d20b54d3f6652a771be"
                 },
                 "m_SlotId": 0
             }
@@ -531,6 +557,20 @@
                     "m_Id": "17e009178e6a40a68a06e89f48b2b115"
                 },
                 "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "87f567242ed74d54ba4bfaa2abc4dd2d"
+                },
+                "m_SlotId": 3
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "8867b250b3a44b7eab8b6bfd474fa78f"
+                },
+                "m_SlotId": 0
             }
         },
         {
@@ -599,6 +639,20 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "d502b54aa80549099c96f8f9a301dd1a"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "9879830bdf834b798c92ff56fb0f5368"
+                },
+                "m_SlotId": 3
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "c9411eca14924bfea26a097d0514636e"
                 },
                 "m_SlotId": 0
             }
@@ -718,13 +772,27 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "d672567a79f1407193e7832652303b2d"
+                },
+                "m_SlotId": 3
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "373939c6fdbb4ca093087071959471a6"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "e73c6524521c4e168187312facdf624c"
                 },
                 "m_SlotId": 1
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "c9411eca14924bfea26a097d0514636e"
+                    "m_Id": "9879830bdf834b798c92ff56fb0f5368"
                 },
                 "m_SlotId": 0
             }
@@ -952,6 +1020,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "048296607dd84e25a926720ee8d883bb",
+    "m_Id": 1,
+    "m_DisplayName": "Min",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Min",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "04a4ed1427a6482ab1185e0036635e5f",
     "m_Group": {
@@ -1104,6 +1196,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "0a551dc0f5004cb9a82c46659d829c9d",
+    "m_Id": 2,
+    "m_DisplayName": "Max",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Max",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.AbsoluteNode",
     "m_ObjectId": "0e3e45fce15343bf8c93b4e3d6b90977",
     "m_Group": {
@@ -1114,10 +1230,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1068.0,
-            "y": 710.0,
+            "x": 1187.9998779296875,
+            "y": 1120.0,
             "width": 208.0,
-            "height": 277.99993896484377
+            "height": 277.9998779296875
         }
     },
     "m_Slots": [
@@ -1304,6 +1420,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "177e38d0522f47479e693f4a7b9e452e",
+    "m_Id": 3,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlendNode",
     "m_ObjectId": "17e009178e6a40a68a06e89f48b2b115",
     "m_Group": {
@@ -1369,6 +1509,30 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "1d0e5acef945451a8ccacb77b6ced68f",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "1e0748358e22479b944f1af729c47139",
     "m_Id": 0,
     "m_DisplayName": "In",
@@ -1381,6 +1545,30 @@
         "y": 0.0,
         "z": 0.0,
         "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "1f75a12148704283a3e7f0165f33277a",
+    "m_Id": 2,
+    "m_DisplayName": "Max",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Max",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
     },
     "m_DefaultValue": {
         "x": 0.0,
@@ -1475,6 +1663,30 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "289a4220972c4ebe9b54b7bb9b1499bf",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -2129,10 +2341,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1187.9998779296875,
-            "y": 22.00000762939453,
-            "width": 208.0,
-            "height": 277.9999694824219
+            "x": 1188.0,
+            "y": 133.99998474121095,
+            "width": 207.9998779296875,
+            "height": 278.0
         }
     },
     "m_Slots": [
@@ -2170,6 +2382,30 @@
         "y": 1.0,
         "z": 1.0,
         "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "42ecf05c7c6748f7b9de2a0d2170a2fa",
+    "m_Id": 3,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     },
     "m_DefaultValue": {
         "x": 0.0,
@@ -2367,10 +2603,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 999.0,
-            "y": 411.0,
+            "x": 1187.9998779296875,
+            "y": 787.0,
             "width": 208.0,
-            "height": 277.99993896484377
+            "height": 278.0
         }
     },
     "m_Slots": [
@@ -2798,6 +3034,50 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ClampNode",
+    "m_ObjectId": "640693e4305f416393cdf739afa9f875",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Clamp",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 1457.0,
+            "y": 1133.0,
+            "width": 208.0,
+            "height": 326.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "1d0e5acef945451a8ccacb77b6ced68f"
+        },
+        {
+            "m_Id": "f41770feaf8844998ec82a23678144f0"
+        },
+        {
+            "m_Id": "0a551dc0f5004cb9a82c46659d829c9d"
+        },
+        {
+            "m_Id": "42ecf05c7c6748f7b9de2a0d2170a2fa"
+        }
+    ],
+    "synonyms": [
+        "limit"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
     "m_ObjectId": "641dd2cd7b0a417aba3d9a724a9ee775",
@@ -2849,6 +3129,30 @@
     "m_SlotType": 0,
     "m_Hidden": false,
     "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "6b4203c27c81474f9b022f2cc686ee9a",
+    "m_Id": 1,
+    "m_DisplayName": "Min",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Min",
     "m_StageCapability": 3,
     "m_Value": {
         "x": 0.0,
@@ -3366,6 +3670,50 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ClampNode",
+    "m_ObjectId": "87f567242ed74d54ba4bfaa2abc4dd2d",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Clamp",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 1457.0,
+            "y": 787.0,
+            "width": 208.0,
+            "height": 326.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "289a4220972c4ebe9b54b7bb9b1499bf"
+        },
+        {
+            "m_Id": "048296607dd84e25a926720ee8d883bb"
+        },
+        {
+            "m_Id": "1f75a12148704283a3e7f0165f33277a"
+        },
+        {
+            "m_Id": "177e38d0522f47479e693f4a7b9e452e"
+        }
+    ],
+    "synonyms": [
+        "limit"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "8857ec6e1eb743379f1a4953b976ac66",
     "m_Group": {
@@ -3480,9 +3828,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 52.99997329711914,
-            "y": 604.0,
-            "width": 208.0,
+            "x": 54.99998092651367,
+            "y": 636.0,
+            "width": 207.99998474121095,
             "height": 302.0
         }
     },
@@ -3858,6 +4206,50 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ClampNode",
+    "m_ObjectId": "9879830bdf834b798c92ff56fb0f5368",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Clamp",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 1457.0,
+            "y": 460.0000305175781,
+            "width": 208.0,
+            "height": 325.9999694824219
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "a595b2bc64214bc7852ec199e2952acb"
+        },
+        {
+            "m_Id": "6b4203c27c81474f9b022f2cc686ee9a"
+        },
+        {
+            "m_Id": "af0f5f93bc83475c8bd5afd638e3e93a"
+        },
+        {
+            "m_Id": "d18bcfced5c8432ab3ed362351ddb242"
+        }
+    ],
+    "synonyms": [
+        "limit"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
     "m_ObjectId": "9905fc06013646bcb515a617b33a3ce2",
@@ -4025,6 +4417,30 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "a595b2bc64214bc7852ec199e2952acb",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
     "m_ObjectId": "a71e17156239400483f488febd08298a",
@@ -4082,6 +4498,30 @@
         "y": 1.0,
         "z": 1.0,
         "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "a9bdb996de03483fa5e56c65751d5cee",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     },
     "m_DefaultValue": {
         "x": 0.0,
@@ -4167,6 +4607,30 @@
     "m_Value": 1.0,
     "m_DefaultValue": 1.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "af0f5f93bc83475c8bd5afd638e3e93a",
+    "m_Id": 2,
+    "m_DisplayName": "Max",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Max",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -4650,6 +5114,30 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "c9b4db4a450d4c448ef0bd9524da96b3",
+    "m_Id": 1,
+    "m_DisplayName": "Min",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Min",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
     "m_ObjectId": "ca466ee1594b42179718f7c934290d9c",
@@ -4810,6 +5298,54 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "d18bcfced5c8432ab3ed362351ddb242",
+    "m_Id": 3,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "d2675ade99da441ea8b34632f30e1d62",
+    "m_Id": 3,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "d3265c60bccc4073b2fc0c4a5a991bcd",
     "m_Id": 0,
     "m_DisplayName": "Base",
@@ -4928,6 +5464,50 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ClampNode",
+    "m_ObjectId": "d672567a79f1407193e7832652303b2d",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Clamp",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 1456.9998779296875,
+            "y": 134.0,
+            "width": 208.0,
+            "height": 326.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "a9bdb996de03483fa5e56c65751d5cee"
+        },
+        {
+            "m_Id": "c9b4db4a450d4c448ef0bd9524da96b3"
+        },
+        {
+            "m_Id": "ff7bc8314e9f4bd89d96e87815130c6c"
+        },
+        {
+            "m_Id": "d2675ade99da441ea8b34632f30e1d62"
+        }
+    ],
+    "synonyms": [
+        "limit"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
     "m_ObjectId": "d9a7eb497c5c4c5c9b39c4d368ae7d0e",
     "m_Id": 0,
@@ -5026,10 +5606,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 80.99995422363281,
-            "y": 166.0,
-            "width": 208.00001525878907,
-            "height": 278.0
+            "x": 1187.9998779296875,
+            "y": 460.0000305175781,
+            "width": 208.0,
+            "height": 277.9999694824219
         }
     },
     "m_Slots": [
@@ -5253,6 +5833,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "f41770feaf8844998ec82a23678144f0",
+    "m_Id": 1,
+    "m_DisplayName": "Min",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Min",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
     "m_ObjectId": "f510d10c83d04173ae79238df2fdb19a",
     "m_Id": 0,
@@ -5456,6 +6060,30 @@
         "y": 0.0,
         "z": 0.0,
         "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "ff7bc8314e9f4bd89d96e87815130c6c",
+    "m_Id": 2,
+    "m_DisplayName": "Max",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Max",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
     },
     "m_DefaultValue": {
         "x": 0.0,

--- a/Assets/Shaders & Materials/Shaders/Shadow VFX_Shader.shadergraph
+++ b/Assets/Shaders & Materials/Shaders/Shadow VFX_Shader.shadergraph
@@ -194,6 +194,18 @@
         },
         {
             "m_Id": "04a4ed1427a6482ab1185e0036635e5f"
+        },
+        {
+            "m_Id": "41f9f40a8a0f469aaf2d91e04f22386e"
+        },
+        {
+            "m_Id": "e73c6524521c4e168187312facdf624c"
+        },
+        {
+            "m_Id": "0e3e45fce15343bf8c93b4e3d6b90977"
+        },
+        {
+            "m_Id": "52eaa389f08d4a36a613b68aa4a1450a"
         }
     ],
     "m_GroupDatas": [],
@@ -250,7 +262,21 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "c9411eca14924bfea26a097d0514636e"
+                    "m_Id": "e73c6524521c4e168187312facdf624c"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "0e3e45fce15343bf8c93b4e3d6b90977"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "57f0403739444d20b54d3f6652a771be"
                 },
                 "m_SlotId": 0
             }
@@ -292,7 +318,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "8867b250b3a44b7eab8b6bfd474fa78f"
+                    "m_Id": "52eaa389f08d4a36a613b68aa4a1450a"
                 },
                 "m_SlotId": 0
             }
@@ -384,6 +410,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "41f9f40a8a0f469aaf2d91e04f22386e"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "373939c6fdbb4ca093087071959471a6"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "4c8bf7a0389a45d8a2e12703fe83c245"
                 },
                 "m_SlotId": 3
@@ -391,6 +431,20 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "04c5f2ed96fa481eb3b43ef5ed160646"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "52eaa389f08d4a36a613b68aa4a1450a"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "8867b250b3a44b7eab8b6bfd474fa78f"
                 },
                 "m_SlotId": 0
             }
@@ -502,7 +556,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "57f0403739444d20b54d3f6652a771be"
+                    "m_Id": "0e3e45fce15343bf8c93b4e3d6b90977"
                 },
                 "m_SlotId": 0
             }
@@ -628,7 +682,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "373939c6fdbb4ca093087071959471a6"
+                    "m_Id": "41f9f40a8a0f469aaf2d91e04f22386e"
                 },
                 "m_SlotId": 0
             }
@@ -659,6 +713,20 @@
                     "m_Id": "16c6db824c2a4bd1bad2b43829e42222"
                 },
                 "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e73c6524521c4e168187312facdf624c"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "c9411eca14924bfea26a097d0514636e"
+                },
+                "m_SlotId": 0
             }
         },
         {
@@ -706,8 +774,8 @@
     ],
     "m_VertexContext": {
         "m_Position": {
-            "x": 1359.0001220703125,
-            "y": 99.9999771118164
+            "x": 1881.9998779296875,
+            "y": 133.99996948242188
         },
         "m_Blocks": [
             {
@@ -723,8 +791,8 @@
     },
     "m_FragmentContext": {
         "m_Position": {
-            "x": 1359.0001220703125,
-            "y": 299.9999084472656
+            "x": 1881.9998779296875,
+            "y": 334.0
         },
         "m_Blocks": [
             {
@@ -963,6 +1031,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "0632b6184060461499afb6e7dd79210c",
+    "m_Id": 1,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "06fbe1121d7746569577a3e51846707f",
     "m_Id": 0,
@@ -1008,6 +1100,44 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "VertexDescription.Tangent"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AbsoluteNode",
+    "m_ObjectId": "0e3e45fce15343bf8c93b4e3d6b90977",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Absolute",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 1068.0,
+            "y": 710.0,
+            "width": 208.0,
+            "height": 277.99993896484377
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "58ae9895920341ef8cce4f6e20569685"
+        },
+        {
+            "m_Id": "0632b6184060461499afb6e7dd79210c"
+        }
+    ],
+    "synonyms": [
+        "positive"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -1102,6 +1232,30 @@
     },
     "m_Labels": [],
     "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "15e8fd8fc36a404b8687334f38045e4b",
+    "m_Id": 1,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -1965,6 +2119,44 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AbsoluteNode",
+    "m_ObjectId": "41f9f40a8a0f469aaf2d91e04f22386e",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Absolute",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 1187.9998779296875,
+            "y": 22.00000762939453,
+            "width": 208.0,
+            "height": 277.9999694824219
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "8d75e880cc204295b1cfb909e80a4d9a"
+        },
+        {
+            "m_Id": "15e8fd8fc36a404b8687334f38045e4b"
+        }
+    ],
+    "synonyms": [
+        "positive"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "42107edf87ad4c64af982c5c158c78b2",
     "m_Id": 1,
@@ -2165,6 +2357,44 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AbsoluteNode",
+    "m_ObjectId": "52eaa389f08d4a36a613b68aa4a1450a",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Absolute",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 999.0,
+            "y": 411.0,
+            "width": 208.0,
+            "height": 277.99993896484377
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "6b05fd81af26401fa377019fed656094"
+        },
+        {
+            "m_Id": "c6f99eb6de504a3b87bfe7df2ab4cdaf"
+        }
+    ],
+    "synonyms": [
+        "positive"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "535163da528c4da685a7a6b55c5ddaf4",
     "m_Id": 0,
@@ -2276,6 +2506,30 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "SurfaceDescription.AlphaClipThreshold"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "58ae9895920341ef8cce4f6e20569685",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -2584,6 +2838,30 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "6b05fd81af26401fa377019fed656094",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -3276,6 +3554,30 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "8d75e880cc204295b1cfb909e80a4d9a",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "8db3aad44f134c99bfde604072987c52",
     "m_Id": 2,
     "m_DisplayName": "Out",
@@ -3699,6 +4001,30 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "a4dd89ea74fc443cb84d0bcc29ecdb15",
+    "m_Id": 1,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
     "m_ObjectId": "a71e17156239400483f488febd08298a",
@@ -3802,6 +4128,30 @@
     },
     "m_Labels": [],
     "m_Space": 2
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "acde6860b7d449279813c25ad94a0244",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -4243,6 +4593,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "c6f99eb6de504a3b87bfe7df2ab4cdaf",
+    "m_Id": 1,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "c9411eca14924bfea26a097d0514636e",
     "m_Group": {
@@ -4637,6 +5011,44 @@
         "y": 0.0,
         "z": 0.0,
         "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AbsoluteNode",
+    "m_ObjectId": "e73c6524521c4e168187312facdf624c",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Absolute",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 80.99995422363281,
+            "y": 166.0,
+            "width": 208.00001525878907,
+            "height": 278.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "acde6860b7d449279813c25ad94a0244"
+        },
+        {
+            "m_Id": "a4dd89ea74fc443cb84d0bcc29ecdb15"
+        }
+    ],
+    "synonyms": [
+        "positive"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
     }
 }
 


### PR DESCRIPTION
# Floor 1
- probe adjustments, lighting toggles mainly

# Floor 2
- Added floor materials like floor 1
- Fixed coffee pot in residential being spun wrong way and clipping into counter

# Prefabs
- Turned all beds to being made OR unmade for now (prev. both on at once) in bedrooms

# Notes
- Doors are generally having a weird lighting issue, I think it has to do with how they blend light probes and I just need to iterate more and adjust them/their model a bit but time is tight. So this may just be an unfortunate bug but I will see what I can do come morning if I can get a few more rounds of baking in
- Resolution of light maps is low right now for the sake of not taking me 25+ minutes. I have it set to 15 for lightmap resolution but it would be nice to get this up to 20-25 before final build. At 15 its like 10 min a bake so there will be little edge artifacts and bleeding issues from the baking process here and there I think.
- Builds take around 15-20 minutes to make from a clean slate 
- Did not get to command, but hangar was doing pretty good after the earlier PR and its bake seems okay so I built. V1.3 is in drive its a little behind from this PR but has Andrews stuff on it! I will do a new build as I go to bed and upload it first thing in the morn