### PR TITLE
Final Build Bugs

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -304,7 +304,14 @@ public class GameManager : MonoBehaviour
         // Resets BOTH game and scene data to properly reset progress
         Instance.GameData = new ProgressionData();
         Instance.SceneData = new ProgressionData();
-    }
+
+        // Clear / Reset all scene data between new game saves (i.e. non-saved data)
+        // i.e. properly reset stuff from previous playthrough if a playthrough is started in the same session
+        DefaultSceneData();
+        FoundLogs = new List<Log>();
+        PlayerEnabled = false; // starts false since scene enter sets it to true
+        LoadPoint = -1; // -1 means logic will default to using resume logic (i.e. picking based on terminal or default pos for station).
+}
 
     // private stored scene data
     private ProgressionData _sceneData;

--- a/Assets/Scripts/Interaction/Interactables/TerminalInteractable.cs
+++ b/Assets/Scripts/Interaction/Interactables/TerminalInteractable.cs
@@ -149,7 +149,6 @@ public class TerminalInteractable : Interactable
         _puzzleCam.gameObject.SetActive(false);
         _terminalCam.gameObject.SetActive(false);
 
-        
         Cursor.visible = false;                     // Right the cursor
         Cursor.lockState = CursorLockMode.Locked;
 

--- a/Assets/Scripts/Interaction/Interactables/TerminalInteractable.cs
+++ b/Assets/Scripts/Interaction/Interactables/TerminalInteractable.cs
@@ -149,8 +149,8 @@ public class TerminalInteractable : Interactable
         _puzzleCam.gameObject.SetActive(false);
         _terminalCam.gameObject.SetActive(false);
 
-        // DO NOT SET VISIBLE TO FALSE - locked mode does this inherently, visible = false just messes up mouse in edge cases of build
-        //Cursor.visible = false;                     // Right the cursor
+        
+        Cursor.visible = false;                     // Right the cursor
         Cursor.lockState = CursorLockMode.Locked;
 
         onLockedInteractionTerminal?.Invoke(false); // Right the HUD

--- a/Assets/Scripts/Interaction/Interactables/TerminalInteractable.cs
+++ b/Assets/Scripts/Interaction/Interactables/TerminalInteractable.cs
@@ -149,7 +149,8 @@ public class TerminalInteractable : Interactable
         _puzzleCam.gameObject.SetActive(false);
         _terminalCam.gameObject.SetActive(false);
 
-        Cursor.visible = false;                     // Right the cursor
+        // DO NOT SET VISIBLE TO FALSE - locked mode does this inherently, visible = false just messes up mouse in edge cases of build
+        //Cursor.visible = false;                     // Right the cursor
         Cursor.lockState = CursorLockMode.Locked;
 
         onLockedInteractionTerminal?.Invoke(false); // Right the HUD

--- a/Assets/Scripts/Interaction/Interactables/WireBoxInteractable.cs
+++ b/Assets/Scripts/Interaction/Interactables/WireBoxInteractable.cs
@@ -142,8 +142,7 @@ public class WireBoxInteractable : Interactable
         _mainCam.gameObject.SetActive(true);
         _wireboxCam.gameObject.SetActive(false);
 
-        // DO NOT SET VISIBLE TO FALSE - locked mode does this inherently, visible = false just messes up mouse in edge cases of build
-        //Cursor.visible = false;
+        Cursor.visible = false;
         Cursor.lockState = CursorLockMode.Locked;
 
         onLockedInteractionWirebox?.Invoke(false);

--- a/Assets/Scripts/Interaction/Interactables/WireBoxInteractable.cs
+++ b/Assets/Scripts/Interaction/Interactables/WireBoxInteractable.cs
@@ -142,7 +142,8 @@ public class WireBoxInteractable : Interactable
         _mainCam.gameObject.SetActive(true);
         _wireboxCam.gameObject.SetActive(false);
 
-        Cursor.visible = false;
+        // DO NOT SET VISIBLE TO FALSE - locked mode does this inherently, visible = false just messes up mouse in edge cases of build
+        //Cursor.visible = false;
         Cursor.lockState = CursorLockMode.Locked;
 
         onLockedInteractionWirebox?.Invoke(false);

--- a/Assets/Scripts/Menus/Pause&Options/PauseControls.cs
+++ b/Assets/Scripts/Menus/Pause&Options/PauseControls.cs
@@ -86,6 +86,7 @@ public class PauseControls : MonoBehaviour
 
             // free control over the mouse
             Cursor.lockState = CursorLockMode.None;
+            Cursor.visible = true;
 
             Time.timeScale = 0;
             _actionMap.Disable();
@@ -111,7 +112,7 @@ public class PauseControls : MonoBehaviour
         _optionsMenu.SetActive(false); // ensure options also closes if that was opened (i.e. closed from Escape press)
 
         // lock mouse back to center screen for first-person controls
-        if(GameManager.Instance.PlayerEnabled || !GameManager.Instance.SceneData.IntroCutsceneWatched)  // Enabled check currently used as a shorthand for if a player is in a locked interaction (terminal, wirebox)
+        if (GameManager.Instance.PlayerEnabled || !GameManager.Instance.SceneData.IntroCutsceneWatched)  // Enabled check currently used as a shorthand for if a player is in a locked interaction (terminal, wirebox)
             Cursor.lockState = CursorLockMode.Locked;
 
         // resume controls and time scale

--- a/Assets/Scripts/Menus/Pause&Options/PauseControls.cs
+++ b/Assets/Scripts/Menus/Pause&Options/PauseControls.cs
@@ -113,7 +113,10 @@ public class PauseControls : MonoBehaviour
 
         // lock mouse back to center screen for first-person controls
         if (GameManager.Instance.PlayerEnabled || !GameManager.Instance.SceneData.IntroCutsceneWatched)  // Enabled check currently used as a shorthand for if a player is in a locked interaction (terminal, wirebox)
+        {
             Cursor.lockState = CursorLockMode.Locked;
+            Cursor.visible = false;
+        }
 
         // resume controls and time scale
         Time.timeScale = 1;

--- a/Assets/Scripts/Menus/Scene Transitions/SceneTransitionHandler.cs
+++ b/Assets/Scripts/Menus/Scene Transitions/SceneTransitionHandler.cs
@@ -55,6 +55,7 @@ public class SceneTransitionHandler : MonoBehaviour
             {
                 // return mouse to first-person mode if not already
                 Cursor.lockState = CursorLockMode.Locked;
+                Cursor.visible = false;
 
                 SceneManager.LoadScene("DeathRealm");
             }
@@ -66,24 +67,28 @@ public class SceneTransitionHandler : MonoBehaviour
                     case 0:
                         // return mouse to first-person mode if not already
                         Cursor.lockState = CursorLockMode.Locked;
+                        Cursor.visible = false;
 
                         SceneManager.LoadScene("Hangar");
                         break;
                     case 1:
                         // return mouse to first-person mode if not already
                         Cursor.lockState = CursorLockMode.Locked;
+                        Cursor.visible = false;
 
                         SceneManager.LoadScene("Floor1");
                         break;
                     case 2:
                         // return mouse to first-person mode if not already
                         Cursor.lockState = CursorLockMode.Locked;
+                        Cursor.visible = false;
 
                         SceneManager.LoadScene("Floor2");
                         break;
                     case 3:
                         // return mouse to first-person mode if not already
                         Cursor.lockState = CursorLockMode.Locked;
+                        Cursor.visible = false;
 
                         SceneManager.LoadScene("Command");
                         break;

--- a/Assets/Scripts/Menus/Start/StartMenuHandler.cs
+++ b/Assets/Scripts/Menus/Start/StartMenuHandler.cs
@@ -72,6 +72,7 @@ public class StartMenuHandler : MonoBehaviour
         // free control over the mouse
         // necessary for when coming back from death realm death ending
         Cursor.lockState = CursorLockMode.None;
+        Cursor.visible = true;
 
         // Only show resume button if there is save data to resume with
         if (!GameManager.Instance.SceneData.NewGameStarted)

--- a/Assets/Scripts/Player/StarterAssetsInputs.cs
+++ b/Assets/Scripts/Player/StarterAssetsInputs.cs
@@ -58,7 +58,11 @@ namespace StarterAssets
 				_firstSceneLoad = true;	// only do override first time on scene load (special case handled different from re-focusing)
 			}
 			else
-				SetCursorState(false);	// free cursor
+				SetCursorState(false);  // free cursor
+
+			// ENSURE CURSOR VISIBLE
+			// if cursor is locked, it is not visible anyways, so just make it visible to be safe
+			Cursor.visible = true;
 		}
         private void OnDisable()
         {

--- a/Assets/Scripts/Player/StarterAssetsInputs.cs
+++ b/Assets/Scripts/Player/StarterAssetsInputs.cs
@@ -59,10 +59,6 @@ namespace StarterAssets
 			}
 			else
 				SetCursorState(false);  // free cursor
-
-			// ENSURE CURSOR VISIBLE
-			// if cursor is locked, it is not visible anyways, so just make it visible to be safe
-			Cursor.visible = true;
 		}
         private void OnDisable()
         {
@@ -175,6 +171,10 @@ namespace StarterAssets
 		private void SetCursorState(bool newState)
 		{
 			Cursor.lockState = newState ? CursorLockMode.Locked : CursorLockMode.None;
+			if (newState)
+				Cursor.visible = false;
+			else
+				Cursor.visible = true;
 		}
 	}
 	

--- a/Assets/Shaders & Materials/Materials/Research/GlowGoop.mat
+++ b/Assets/Shaders & Materials/Materials/Research/GlowGoop.mat
@@ -15,7 +15,7 @@ Material:
   - _ALPHAPREMULTIPLY_ON
   - _EMISSION
   m_InvalidKeywords: []
-  m_LightmapFlags: 2
+  m_LightmapFlags: 1
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: 3000
@@ -82,5 +82,5 @@ Material:
     - _ZWrite: 0
     m_Colors:
     - _Color: {r: 0, g: 0, b: 0, a: 0.25490198}
-    - _EmissionColor: {r: 0.015686274, g: 0.5, b: 0, a: 1}
+    - _EmissionColor: {r: 0.047058735, g: 1.4980392, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Shaders & Materials/Materials/Room Specific Materials/Research Tile 1.mat
+++ b/Assets/Shaders & Materials/Materials/Room Specific Materials/Research Tile 1.mat
@@ -59,7 +59,7 @@ Material:
     - _Noise3Intensity: -0.04
     - _Noise3Seed: 3.83
     - _NoiseNormals: 0
-    - _NoiseRoughness: 0.54
+    - _NoiseRoughness: 0.69
     - _NoiseRoughnessIntensity: 1
     - _Noise_Normals_On: 0
     - _Normal_Texture_On: 0
@@ -69,11 +69,12 @@ Material:
     - _OverallNoiseScale_1: 41.4
     - _Scale: 1
     - _Smoothnness: 41.4
+    - _TextureNormalIntensity: 1
     - _TextureTiling: 0.5
     - _Transitions: 0.5
     - _TriPlaneBlur: 0.5
     m_Colors:
-    - _BaseColor: {r: 0.44, g: 0.44, b: 0.44, a: 0.2627451}
+    - _BaseColor: {r: 0.7924528, g: 0.7924528, b: 0.7924528, a: 0.2627451}
     - _Transition: {r: 32, g: 32, b: 32, a: 0}
   m_BuildTextureStacks: []
 --- !u!114 &2119745265945795886


### PR DESCRIPTION
- Patched **Cursor Visibility Bug**: I made sure that 100% all cases of mouse enable/disabling proper sets visible state alongside the locked state
  - I was seriously not able to replicate the issue anymore with anything to do with pause menu or terminal interface with various tabbing outs
- Logs and all other scene data (i.e. not stored in save data between sessions) now properly reset on creating a new game save during a single session
  - the main thing this fixed was the log issues, but it potentially addressed some other issues we hadn't see yet regarding resetting of PlayerEnabled and LoadPoint