### PR TITLE
Touch Ups

### DIFF
--- a/Assets/Prefabs/Creature/Shadow VFX.prefab
+++ b/Assets/Prefabs/Creature/Shadow VFX.prefab
@@ -17060,7 +17060,7 @@ ParticleSystem:
     x:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 1
+      scalar: 0
       minScalar: 0
       maxCurve:
         serializedVersion: 2
@@ -17113,7 +17113,7 @@ ParticleSystem:
     y:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 20
+      scalar: 0
       minScalar: 0
       maxCurve:
         serializedVersion: 2
@@ -17166,7 +17166,7 @@ ParticleSystem:
     z:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 10
+      scalar: 0
       minScalar: 5
       maxCurve:
         serializedVersion: 2

--- a/Assets/Prefabs/HUD/File Tab.prefab
+++ b/Assets/Prefabs/HUD/File Tab.prefab
@@ -5791,7 +5791,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &2175302444253038725
 RectTransform:
   m_ObjectHideFlags: 0
@@ -6030,7 +6030,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 15.000107, y: -167.99997}
+  m_AnchoredPosition: {x: 15.000107, y: -178}
   m_SizeDelta: {x: 538.2256, y: 50.006104}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &5178512722572267179
@@ -7845,7 +7845,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 7.0575867, y: 158}
+  m_AnchoredPosition: {x: 2, y: 158}
   m_SizeDelta: {x: 483.1, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &58470056015335373
@@ -8903,13 +8903,14 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3763698648787871250}
+  - component: {fileID: 2259265813739026892}
   m_Layer: 5
   m_Name: Text Display
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &3763698648787871250
 RectTransform:
   m_ObjectHideFlags: 0
@@ -8922,6 +8923,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 8445487822266756820}
+  - {fileID: 1728482202192339395}
   - {fileID: 4744394372379193479}
   - {fileID: 7147644412039549938}
   - {fileID: 845809316271175436}
@@ -8933,6 +8936,14 @@ RectTransform:
   m_AnchoredPosition: {x: 0.9426422, y: -92}
   m_SizeDelta: {x: 497.21472, y: 402.38446}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2259265813739026892
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7408290621213977936}
+  m_CullTransparentMesh: 1
 --- !u!1 &7505455509043971598
 GameObject:
   m_ObjectHideFlags: 0
@@ -10174,6 +10185,82 @@ MonoBehaviour:
   m_FillOrigin: 1
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8404935672279117183
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1728482202192339395}
+  - component: {fileID: 8688454792451429025}
+  - component: {fileID: 6808850896987675557}
+  m_Layer: 5
+  m_Name: Backer Img - Dark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1728482202192339395
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8404935672279117183}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3763698648787871250}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.86, y: 29.98}
+  m_SizeDelta: {x: 492.36, y: 335.3238}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8688454792451429025
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8404935672279117183}
+  m_CullTransparentMesh: 1
+--- !u!114 &6808850896987675557
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8404935672279117183}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.027450982, g: 0.2627451, b: 0.47450984, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8584819016275800610
 GameObject:
   m_ObjectHideFlags: 0
@@ -10836,6 +10923,82 @@ MonoBehaviour:
   m_Sprite: {fileID: 21300000, guid: 4530b0d50a5878b4d9003493d8ab4640, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &9124093740025729786
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8445487822266756820}
+  - component: {fileID: 2725847686341177541}
+  - component: {fileID: 468008925572535286}
+  m_Layer: 5
+  m_Name: Backer Img - Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8445487822266756820
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9124093740025729786}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3763698648787871250}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.86, y: 29.98}
+  m_SizeDelta: {x: 505.55, y: 354.16}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2725847686341177541
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9124093740025729786}
+  m_CullTransparentMesh: 1
+--- !u!114 &468008925572535286
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9124093740025729786}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.003921569, g: 0.5921569, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1

--- a/Assets/Prefabs/HUD/File Tab.prefab
+++ b/Assets/Prefabs/HUD/File Tab.prefab
@@ -5791,7 +5791,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2175302444253038725
 RectTransform:
   m_ObjectHideFlags: 0
@@ -8910,7 +8910,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &3763698648787871250
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/HUD/File Tab.prefab
+++ b/Assets/Prefabs/HUD/File Tab.prefab
@@ -508,6 +508,82 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &423228186316649028
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1984747131063077821}
+  - component: {fileID: 8828543779749793996}
+  - component: {fileID: 97344776333301115}
+  m_Layer: 5
+  m_Name: Background - Outline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1984747131063077821
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 423228186316649028}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 0.5, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3107542410638326860}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -0.723999, y: 0}
+  m_SizeDelta: {x: 0.1254, y: 4.2956}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8828543779749793996
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 423228186316649028}
+  m_CullTransparentMesh: 1
+--- !u!114 &97344776333301115
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 423228186316649028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &436676004995552322
 GameObject:
   m_ObjectHideFlags: 0
@@ -1330,6 +1406,7 @@ RectTransform:
   m_LocalScale: {x: 2.2, y: 2.2, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1984747131063077821}
   - {fileID: 2707649276782245872}
   - {fileID: 6793081739353698735}
   - {fileID: 826992608903816919}
@@ -1870,7 +1947,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -113.000114, y: 16.999939}
+  m_AnchoredPosition: {x: -121.1, y: 16.999939}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6131849765054872384
@@ -1945,7 +2022,7 @@ RectTransform:
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: -5, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -2964,7 +3041,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 21, y: 0.000015258789}
+  m_AnchoredPosition: {x: 169.2, y: 0.000015258789}
   m_SizeDelta: {x: 538.16, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5502611229769548630
@@ -3029,7 +3106,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 2
+  m_HorizontalAlignment: 1
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 3.02
@@ -4549,7 +4626,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -318.99973, y: 80}
+  m_AnchoredPosition: {x: -328, y: 80}
   m_SizeDelta: {x: 142.96, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1621727970255427699
@@ -5698,6 +5775,158 @@ RectTransform:
   m_AnchoredPosition: {x: 55.999893, y: 0}
   m_SizeDelta: {x: 538.2256, y: 50.006104}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4581333576393360489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2444311923776257016}
+  - component: {fileID: 2211665141822880329}
+  - component: {fileID: 8856052112152100966}
+  m_Layer: 5
+  m_Name: Backer Img - Dark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2444311923776257016
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4581333576393360489}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8069650092213397126}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.85998535, y: 29.97998}
+  m_SizeDelta: {x: 492.36, y: 335.3238}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2211665141822880329
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4581333576393360489}
+  m_CullTransparentMesh: 1
+--- !u!114 &8856052112152100966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4581333576393360489}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.027450982, g: 0.2627451, b: 0.47450984, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4781039460308650518
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3983173639466109240}
+  - component: {fileID: 5482308523442545440}
+  - component: {fileID: 4013264640559988522}
+  m_Layer: 5
+  m_Name: Backer Img - Dark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3983173639466109240
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4781039460308650518}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2650180680080483603}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.85998535, y: 29.97998}
+  m_SizeDelta: {x: 492.36, y: 335.3238}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5482308523442545440
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4781039460308650518}
+  m_CullTransparentMesh: 1
+--- !u!114 &4013264640559988522
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4781039460308650518}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.027450982, g: 0.2627451, b: 0.47450984, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4824318407468490650
 GameObject:
   m_ObjectHideFlags: 0
@@ -6220,8 +6449,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 7.0575867, y: -70.3}
-  m_SizeDelta: {x: 483.1, y: 50}
+  m_AnchoredPosition: {x: 2.7, y: -70.3}
+  m_SizeDelta: {x: 474.42, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2780674337026717883
 CanvasRenderer:
@@ -7502,7 +7731,7 @@ RectTransform:
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -7572,6 +7801,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 8749541360740055473}
+  - {fileID: 3983173639466109240}
   - {fileID: 6561795703186923944}
   - {fileID: 2472559443641421757}
   m_Father: {fileID: 2175302444253038725}
@@ -8742,6 +8973,158 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7076796705851367600
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8749541360740055473}
+  - component: {fileID: 9092213318221267394}
+  - component: {fileID: 268684468746132718}
+  m_Layer: 5
+  m_Name: Backer Img - Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8749541360740055473
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7076796705851367600}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2650180680080483603}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.85998535, y: 29.97998}
+  m_SizeDelta: {x: 505.55, y: 354.16}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9092213318221267394
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7076796705851367600}
+  m_CullTransparentMesh: 1
+--- !u!114 &268684468746132718
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7076796705851367600}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.003921569, g: 0.5921569, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7169572966915193780
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2959614095237165418}
+  - component: {fileID: 6537858733585356697}
+  - component: {fileID: 3741953868547994305}
+  m_Layer: 5
+  m_Name: Backer Img - Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2959614095237165418
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7169572966915193780}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8069650092213397126}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.85998535, y: 29.97998}
+  m_SizeDelta: {x: 505.55, y: 354.16}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6537858733585356697
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7169572966915193780}
+  m_CullTransparentMesh: 1
+--- !u!114 &3741953868547994305
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7169572966915193780}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.003921569, g: 0.5921569, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &7183276678394840077
 GameObject:
   m_ObjectHideFlags: 0
@@ -9715,6 +10098,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 2959614095237165418}
+  - {fileID: 2444311923776257016}
   - {fileID: 6836745931112437848}
   - {fileID: 3107542410638326860}
   - {fileID: 2436185216940555886}
@@ -10296,7 +10681,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 7.0575867, y: -121}
+  m_AnchoredPosition: {x: -0.3, y: -121}
   m_SizeDelta: {x: 483.1, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8820351245614517425

--- a/Assets/Prefabs/HUD/Home Tab.prefab
+++ b/Assets/Prefabs/HUD/Home Tab.prefab
@@ -415,7 +415,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -72, y: -115}
+  m_AnchoredPosition: {x: -49.30002, y: -115}
   m_SizeDelta: {x: 178.33, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4530811496062821500
@@ -446,9 +446,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'StarLight v2.0.9
-
-    Connection status: online'
+  m_text: StarLight v2.0.9
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
   m_sharedMaterial: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
@@ -481,7 +479,7 @@ MonoBehaviour:
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
-  m_fontStyle: 0
+  m_fontStyle: 1
   m_HorizontalAlignment: 1
   m_VerticalAlignment: 256
   m_textAlignment: 65535
@@ -1126,6 +1124,82 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3384955025536003707
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4384997120185310706}
+  - component: {fileID: 679413442587519309}
+  - component: {fileID: 5522435425524288425}
+  m_Layer: 5
+  m_Name: Charge Fill - Backer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4384997120185310706
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3384955025536003707}
+  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.11748959, y: 0.7, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4287998870516698681}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -56.8, y: 30.8}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &679413442587519309
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3384955025536003707}
+  m_CullTransparentMesh: 1
+--- !u!114 &5522435425524288425
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3384955025536003707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.3529412, b: 0.6, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 1
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 1
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3523181452005993595
@@ -1927,6 +2001,7 @@ RectTransform:
   - {fileID: 3433323200161087965}
   - {fileID: 5253418940654825939}
   - {fileID: 4463885000765199157}
+  - {fileID: 4384997120185310706}
   - {fileID: 7083285191526481352}
   m_Father: {fileID: 8097947144369989188}
   m_RootOrder: -1

--- a/Assets/Prefabs/HUD/Player HUD.prefab
+++ b/Assets/Prefabs/HUD/Player HUD.prefab
@@ -10360,18 +10360,6 @@ PrefabInstance:
       propertyPath: _mainHUD
       value: 
       objectReference: {fileID: 8061570771452208166}
-    - target: {fileID: 3433323200161087965, guid: bd77a50ffae39a3438dc2483c4bd7ce4, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -49.30002
-      objectReference: {fileID: 0}
-    - target: {fileID: 4518913416830969615, guid: bd77a50ffae39a3438dc2483c4bd7ce4, type: 3}
-      propertyPath: m_text
-      value: StarLight v2.0.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 4518913416830969615, guid: bd77a50ffae39a3438dc2483c4bd7ce4, type: 3}
-      propertyPath: m_fontStyle
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 5816914269451954804, guid: bd77a50ffae39a3438dc2483c4bd7ce4, type: 3}
       propertyPath: m_Name
       value: Home Tab

--- a/Assets/Prefabs/Interactables/Door Switches.prefab
+++ b/Assets/Prefabs/Interactables/Door Switches.prefab
@@ -674,6 +674,9 @@ MonoBehaviour:
   _elecOperableNo: {fileID: 21300000, guid: f634ecad502e59848a55792726cd43c2, type: 3}
   _indicatorParent: {fileID: 8963621751297996585}
   _interactPromptParent: {fileID: 3028033344464032018}
+  _keycardReqObjs:
+  - {fileID: 368258411345040167}
+  - {fileID: 4002691939573695665}
   DoorCloseDistance: 0
   IsActiveDoorCoroutine: 0
   RequiredKey: 4
@@ -11089,6 +11092,9 @@ MonoBehaviour:
   _elecOperableNo: {fileID: 21300000, guid: f634ecad502e59848a55792726cd43c2, type: 3}
   _indicatorParent: {fileID: 1466153518336825275}
   _interactPromptParent: {fileID: 5274532410549882820}
+  _keycardReqObjs:
+  - {fileID: 1238190727643421501}
+  - {fileID: 6225695809437710670}
   DoorCloseDistance: 0
   IsActiveDoorCoroutine: 0
   RequiredKey: 4

--- a/Assets/Prefabs/ModularPrefabs/Interaction Objects/Door Small Plain Wall.prefab
+++ b/Assets/Prefabs/ModularPrefabs/Interaction Objects/Door Small Plain Wall.prefab
@@ -444,6 +444,18 @@ PrefabInstance:
       propertyPath: DoorAnim
       value: 
       objectReference: {fileID: 8131509351805305884}
+    - target: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+      propertyPath: _keycardReqObjs.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+      propertyPath: _keycardReqObjs.Array.data[0]
+      value: 
+      objectReference: {fileID: 5619360661091207594}
+    - target: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+      propertyPath: _keycardReqObjs.Array.data[1]
+      value: 
+      objectReference: {fileID: 770968813965880281}
     - target: {fileID: 1579165581714846029, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
       propertyPath: m_UseCustomVertexStreams
       value: 1
@@ -548,6 +560,18 @@ PrefabInstance:
       propertyPath: DoorAnim
       value: 
       objectReference: {fileID: 8131509351805305884}
+    - target: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+      propertyPath: _keycardReqObjs.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+      propertyPath: _keycardReqObjs.Array.data[0]
+      value: 
+      objectReference: {fileID: 6469777403940848048}
+    - target: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+      propertyPath: _keycardReqObjs.Array.data[1]
+      value: 
+      objectReference: {fileID: 7735352695907096102}
     - target: {fileID: 7986699092409988405, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
       propertyPath: m_UseCustomVertexStreams
       value: 1
@@ -606,6 +630,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6512841599045629329, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
   m_PrefabInstance: {fileID: 6689276287895933591}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &770968813965880281 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6225695809437710670, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+  m_PrefabInstance: {fileID: 6689276287895933591}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3826929600264295126 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
@@ -617,6 +646,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf793f0592c395540bf1c8cb39d986cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &5619360661091207594 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1238190727643421501, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+  m_PrefabInstance: {fileID: 6689276287895933591}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6301874696814177089 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
@@ -628,3 +662,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf793f0592c395540bf1c8cb39d986cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &6469777403940848048 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 368258411345040167, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+  m_PrefabInstance: {fileID: 6689276287895933591}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7735352695907096102 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4002691939573695665, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+  m_PrefabInstance: {fileID: 6689276287895933591}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/ModularPrefabs/Interaction Objects/Door Small Plain Wall.prefab
+++ b/Assets/Prefabs/ModularPrefabs/Interaction Objects/Door Small Plain Wall.prefab
@@ -444,18 +444,6 @@ PrefabInstance:
       propertyPath: DoorAnim
       value: 
       objectReference: {fileID: 8131509351805305884}
-    - target: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-      propertyPath: _keycardReqObjs.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-      propertyPath: _keycardReqObjs.Array.data[0]
-      value: 
-      objectReference: {fileID: 5619360661091207594}
-    - target: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-      propertyPath: _keycardReqObjs.Array.data[1]
-      value: 
-      objectReference: {fileID: 770968813965880281}
     - target: {fileID: 1579165581714846029, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
       propertyPath: m_UseCustomVertexStreams
       value: 1
@@ -560,18 +548,6 @@ PrefabInstance:
       propertyPath: DoorAnim
       value: 
       objectReference: {fileID: 8131509351805305884}
-    - target: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-      propertyPath: _keycardReqObjs.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-      propertyPath: _keycardReqObjs.Array.data[0]
-      value: 
-      objectReference: {fileID: 6469777403940848048}
-    - target: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-      propertyPath: _keycardReqObjs.Array.data[1]
-      value: 
-      objectReference: {fileID: 7735352695907096102}
     - target: {fileID: 7986699092409988405, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
       propertyPath: m_UseCustomVertexStreams
       value: 1
@@ -630,11 +606,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6512841599045629329, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
   m_PrefabInstance: {fileID: 6689276287895933591}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &770968813965880281 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6225695809437710670, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-  m_PrefabInstance: {fileID: 6689276287895933591}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3826929600264295126 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
@@ -646,11 +617,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf793f0592c395540bf1c8cb39d986cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &5619360661091207594 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1238190727643421501, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-  m_PrefabInstance: {fileID: 6689276287895933591}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6301874696814177089 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
@@ -662,13 +628,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf793f0592c395540bf1c8cb39d986cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &6469777403940848048 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 368258411345040167, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-  m_PrefabInstance: {fileID: 6689276287895933591}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &7735352695907096102 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4002691939573695665, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-  m_PrefabInstance: {fileID: 6689276287895933591}
-  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/ModularPrefabs/Interaction Objects/DoorPlainWall.prefab
+++ b/Assets/Prefabs/ModularPrefabs/Interaction Objects/DoorPlainWall.prefab
@@ -207,18 +207,6 @@ PrefabInstance:
       propertyPath: DoorAnim
       value: 
       objectReference: {fileID: 5499831896906314450}
-    - target: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-      propertyPath: _keycardReqObjs.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-      propertyPath: _keycardReqObjs.Array.data[0]
-      value: 
-      objectReference: {fileID: 4980202792104932473}
-    - target: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-      propertyPath: _keycardReqObjs.Array.data[1]
-      value: 
-      objectReference: {fileID: 168267880975095306}
     - target: {fileID: 1579165581714846029, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
       propertyPath: m_UseCustomVertexStreams
       value: 1
@@ -323,18 +311,6 @@ PrefabInstance:
       propertyPath: DoorAnim
       value: 
       objectReference: {fileID: 5499831896906314450}
-    - target: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-      propertyPath: _keycardReqObjs.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-      propertyPath: _keycardReqObjs.Array.data[0]
-      value: 
-      objectReference: {fileID: 5850038440364194915}
-    - target: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-      propertyPath: _keycardReqObjs.Array.data[1]
-      value: 
-      objectReference: {fileID: 7187666910598720501}
     - target: {fileID: 7986699092409988405, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
       propertyPath: m_UseCustomVertexStreams
       value: 1
@@ -388,11 +364,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
---- !u!1 &168267880975095306 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6225695809437710670, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-  m_PrefabInstance: {fileID: 6067426105806876484}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1031765253392472789 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6512841599045629329, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
@@ -409,16 +380,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf793f0592c395540bf1c8cb39d986cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &4980202792104932473 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1238190727643421501, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-  m_PrefabInstance: {fileID: 6067426105806876484}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &5850038440364194915 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 368258411345040167, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-  m_PrefabInstance: {fileID: 6067426105806876484}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6886574579248420498 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
@@ -430,11 +391,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf793f0592c395540bf1c8cb39d986cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &7187666910598720501 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4002691939573695665, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
-  m_PrefabInstance: {fileID: 6067426105806876484}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8277759584508830462
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ModularPrefabs/Interaction Objects/DoorPlainWall.prefab
+++ b/Assets/Prefabs/ModularPrefabs/Interaction Objects/DoorPlainWall.prefab
@@ -207,6 +207,18 @@ PrefabInstance:
       propertyPath: DoorAnim
       value: 
       objectReference: {fileID: 5499831896906314450}
+    - target: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+      propertyPath: _keycardReqObjs.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+      propertyPath: _keycardReqObjs.Array.data[0]
+      value: 
+      objectReference: {fileID: 4980202792104932473}
+    - target: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+      propertyPath: _keycardReqObjs.Array.data[1]
+      value: 
+      objectReference: {fileID: 168267880975095306}
     - target: {fileID: 1579165581714846029, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
       propertyPath: m_UseCustomVertexStreams
       value: 1
@@ -311,6 +323,18 @@ PrefabInstance:
       propertyPath: DoorAnim
       value: 
       objectReference: {fileID: 5499831896906314450}
+    - target: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+      propertyPath: _keycardReqObjs.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+      propertyPath: _keycardReqObjs.Array.data[0]
+      value: 
+      objectReference: {fileID: 5850038440364194915}
+    - target: {fileID: 7624287842345500737, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+      propertyPath: _keycardReqObjs.Array.data[1]
+      value: 
+      objectReference: {fileID: 7187666910598720501}
     - target: {fileID: 7986699092409988405, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
       propertyPath: m_UseCustomVertexStreams
       value: 1
@@ -364,6 +388,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+--- !u!1 &168267880975095306 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6225695809437710670, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+  m_PrefabInstance: {fileID: 6067426105806876484}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1031765253392472789 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6512841599045629329, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
@@ -380,6 +409,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf793f0592c395540bf1c8cb39d986cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &4980202792104932473 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1238190727643421501, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+  m_PrefabInstance: {fileID: 6067426105806876484}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5850038440364194915 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 368258411345040167, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+  m_PrefabInstance: {fileID: 6067426105806876484}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6886574579248420498 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 838185142904863190, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
@@ -391,6 +430,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf793f0592c395540bf1c8cb39d986cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &7187666910598720501 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4002691939573695665, guid: f918aa3ab9a666b40a8c20c93727cedc, type: 3}
+  m_PrefabInstance: {fileID: 6067426105806876484}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8277759584508830462
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Power Management/PowerSystem.prefab
+++ b/Assets/Prefabs/Power Management/PowerSystem.prefab
@@ -127,7 +127,6 @@ Transform:
   m_Children:
   - {fileID: 8086927472127571018}
   - {fileID: 242701287297242336}
-  - {fileID: 7335579165618806781}
   - {fileID: 2321128728152294702}
   m_Father: {fileID: 1436419456269457835}
   m_RootOrder: -1
@@ -444,7 +443,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1576010191542240730}
-  - {fileID: 5513855084159152785}
   - {fileID: 4979457029560533629}
   m_Father: {fileID: 1436419456269457835}
   m_RootOrder: -1
@@ -573,8 +571,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3325610816649525398}
-  - {fileID: 8072096585594789532}
-  - {fileID: 1510328651769175620}
   - {fileID: 6806329767089803084}
   - {fileID: 5273588428591520359}
   - {fileID: 7228481188892540246}
@@ -1041,7 +1037,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -15.42744
+      value: -15.4086895
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.y
@@ -1193,7 +1189,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 12.872585
+      value: 12.7163105
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.y
@@ -1279,27 +1275,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1.1237054
+      value: 1.1362062
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9999983
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0018593326
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 6.4727673e-10
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.213
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -1435,7 +1431,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 10.123705
+      value: 10.136206
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1661,7 +1657,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -2.1274357
+      value: 6.8413105
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.y
@@ -1669,7 +1665,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 28.323706
+      value: 28.261206
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1794,80 +1790,6 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
   m_PrefabInstance: {fileID: 1777386266241203647}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1867718478796651291
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 5091289407748237826}
-    m_Modifications:
-    - target: {fileID: -510298546331924569, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -32.22744
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.123833
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 29.823706
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3798321670694567729, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: RequiredKey
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5924911849745368872, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_Name
-      value: DOOR - Cargo Processing / Quarantine Entry
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
---- !u!4 &1510328651769175620 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-  m_PrefabInstance: {fileID: 1867718478796651291}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2133386089792163019
 PrefabInstance:
@@ -2347,7 +2269,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -24.827438
+      value: -24.78369
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.y
@@ -2495,7 +2417,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 12.8725815
+      value: 12.8100605
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.y
@@ -3377,7 +3299,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -32.22744
+      value: -32.25244
       objectReference: {fileID: 0}
     - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
       propertyPath: m_LocalPosition.y
@@ -3385,7 +3307,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 23.823706
+      value: 23.761206
       objectReference: {fileID: 0}
     - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -3589,84 +3511,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
   m_PrefabInstance: {fileID: 5110342548384737434}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &5247810648979150987
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 711199449381708919}
-    m_Modifications:
-    - target: {fileID: 3190364584999887557, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_Name
-      value: DOOR - Engineering Hall / Engineering
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -26.22744
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.123833
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 7.322
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3735544368153762662, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4965146530036814926, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: IsOpen
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4965146530036814926, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: IsBroken
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
---- !u!4 &7335579165618806781 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-  m_PrefabInstance: {fileID: 5247810648979150987}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5282292240202693152
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3685,7 +3529,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -32.22744
+      value: -32.22119
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.y
@@ -3763,7 +3607,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -33.62744
+      value: -33.623
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.y
@@ -3771,27 +3615,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -4.551294
+      value: -4.552
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9999983
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0018593327
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 6.402842e-10
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.213
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -4075,27 +3919,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1.1237054
+      value: 1.1362062
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9999983
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0018593326
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 6.4727673e-10
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.213
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -4379,27 +4223,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 10.123705
+      value: 10.136206
       objectReference: {fileID: 0}
     - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9999983
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0018593326
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 6.4727673e-10
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.213
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -4426,88 +4270,6 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
   m_PrefabInstance: {fileID: 6530356764006990197}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &7033466369183364583
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 533759476252130961}
-    m_Modifications:
-    - target: {fileID: 3190364584999887557, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_Name
-      value: DOOR - Farm / Farm Hall
-      objectReference: {fileID: 0}
-    - target: {fileID: 3190364584999887557, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 12.692551
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.1222694
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 19.511206
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3735544368153762662, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4965146530036814926, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: IsOpen
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4965146530036814926, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-      propertyPath: IsBroken
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
---- !u!4 &5513855084159152785 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
-  m_PrefabInstance: {fileID: 7033466369183364583}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7108776319867720853
 PrefabInstance:
@@ -4683,7 +4445,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 6.8725834
+      value: 6.8413105
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.y
@@ -5077,7 +4839,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.125
+      value: -2.123833
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.z
@@ -5085,23 +4847,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071055
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0013147464
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071055
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.0013147464
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.213
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -5225,7 +4987,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5.3725796
+      value: 5.3100605
       objectReference: {fileID: 0}
     - target: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
       propertyPath: m_LocalPosition.y
@@ -5280,80 +5042,6 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 3251248846442661750, guid: 7829206be855edd478a4311baf36e9b1, type: 3}
   m_PrefabInstance: {fileID: 8576387446890377950}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &9014907879808170947
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 5091289407748237826}
-    m_Modifications:
-    - target: {fileID: -510298546331924569, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -32.17744
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.123833
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 32.823708
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3798321670694567729, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: RequiredKey
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5924911849745368872, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-      propertyPath: m_Name
-      value: DOOR - Quarantine Entry / Quarantine
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
---- !u!4 &8072096585594789532 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 945399574951929183, guid: b965dc061d7264947ae8ae1f2fb92dd1, type: 3}
-  m_PrefabInstance: {fileID: 9014907879808170947}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &9059383819295571112
 PrefabInstance:

--- a/Assets/Prefabs/Power Management/PowerSystem.prefab
+++ b/Assets/Prefabs/Power Management/PowerSystem.prefab
@@ -364,6 +364,8 @@ MonoBehaviour:
   - {fileID: 7817394144648781019}
   - {fileID: 5454874806440751765}
   - {fileID: 159906052403570085}
+  _overloadDuration: 2
+  OverloadLock: 0
 --- !u!1 &2950226673705062239
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Power Management/Terminal Interface (Canvas).prefab
+++ b/Assets/Prefabs/Power Management/Terminal Interface (Canvas).prefab
@@ -92,7 +92,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &9082802730195104220
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Power Management/Terminal Interface (Canvas).prefab
+++ b/Assets/Prefabs/Power Management/Terminal Interface (Canvas).prefab
@@ -92,7 +92,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &9082802730195104220
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Power Management/Terminal Interface (Canvas).prefab
+++ b/Assets/Prefabs/Power Management/Terminal Interface (Canvas).prefab
@@ -39,6 +39,7 @@ RectTransform:
   - {fileID: 8387604156947767207}
   - {fileID: 5259288183877821121}
   - {fileID: 2788269089400768436}
+  - {fileID: 6034937161006256259}
   m_Father: {fileID: 0}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -704,6 +705,79 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3682381860466592087
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6034937161006256259}
+  - component: {fileID: 1395024470965108496}
+  - component: {fileID: 7395685878779699750}
+  m_Layer: 0
+  m_Name: Boot Screen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6034937161006256259
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3682381860466592087}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8992447578269369893}
+  - {fileID: 7088693091995590736}
+  m_Father: {fileID: 5545132134957757420}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1548, y: 1080}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!225 &1395024470965108496
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3682381860466592087}
+  m_Enabled: 1
+  m_Alpha: 0
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!95 &7395685878779699750
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3682381860466592087}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: bd42a20986220c648b55a1aadc7e4a8a, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &4163352001405745557
 GameObject:
   m_ObjectHideFlags: 0
@@ -771,6 +845,82 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4272767295632428392
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7088693091995590736}
+  - component: {fileID: 2512984341019691087}
+  - component: {fileID: 9105677511722650056}
+  m_Layer: 0
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7088693091995590736
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4272767295632428392}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6034937161006256259}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 750, y: 750}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2512984341019691087
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4272767295632428392}
+  m_CullTransparentMesh: 1
+--- !u!114 &9105677511722650056
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4272767295632428392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.28627452, b: 0.48235294, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a8c5ee4729bf47f409a0e3302d7510b6, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1490,6 +1640,82 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6996499740169265736
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8992447578269369893}
+  - component: {fileID: 709096841111101441}
+  - component: {fileID: 5591203732853466578}
+  m_Layer: 0
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8992447578269369893
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6996499740169265736}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6034937161006256259}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1548, y: 1080}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &709096841111101441
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6996499740169265736}
+  m_CullTransparentMesh: 1
+--- !u!114 &5591203732853466578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6996499740169265736}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.6307428, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &7113447675879857028
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Power Management/Terminal Interface (Canvas).prefab
+++ b/Assets/Prefabs/Power Management/Terminal Interface (Canvas).prefab
@@ -134,8 +134,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 545730424823536159}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 33, z: 0}
-  m_LocalScale: {x: 12, y: 12, z: 12}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 8541110124373687948}
@@ -184,7 +184,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 150}
+  m_AnchoredPosition: {x: 0, y: 125}
   m_SizeDelta: {x: 480.3, y: 91.8}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3212028630461433320
@@ -215,10 +215,10 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Grid Capacity:'
+  m_text: 'Power Usage:'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+  m_sharedMaterial: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -249,7 +249,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 4
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -309,7 +309,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 855892784674664665}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -4}
   m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
   m_ConstrainProportionsScale: 1
   m_Children:
@@ -321,7 +321,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -625, y: 0}
+  m_AnchoredPosition: {x: -625, y: -80}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7104287938954230712
@@ -381,7 +381,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 75}
+  m_AnchoredPosition: {x: 0, y: 175}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4055845367327211246
@@ -405,7 +405,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.2924528, g: 0.2924528, b: 0.2924528, a: 1}
+  m_Color: {r: 0, g: 0.28627452, b: 0.48235294, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -517,7 +517,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1676443391868631310}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 12}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -526,7 +526,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -72.5}
+  m_AnchoredPosition: {x: 0, y: -115}
   m_SizeDelta: {x: 297.4, y: 311.9}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3374228396418211588
@@ -557,12 +557,12 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: '###
+  m_text: '100
 
-    ###'
+    200'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+  m_sharedMaterial: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -687,7 +687,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 154583c472c83e94b9f1ebbf5d0224aa, type: 2}
-  m_Color: {r: 0.6053756, g: 0.6919662, b: 0.7169812, a: 0.7607843}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.7607843}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -739,7 +739,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.061095, y: -79}
+  m_AnchoredPosition: {x: 0, y: -105}
   m_SizeDelta: {x: 261.91, y: 15.12}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5856261384058120927
@@ -1005,6 +1005,8 @@ RectTransform:
   - {fileID: 637032467342853900}
   - {fileID: 5520431900549413507}
   - {fileID: 6142981921842812293}
+  - {fileID: 7184744700479718581}
+  - {fileID: 7960743205689609493}
   m_Father: {fileID: 5545132134957757420}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1027,6 +1029,141 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _terminal: {fileID: 0}
   _textDisplay: {fileID: 8584871779215987811}
+--- !u!1 &5424969938168003667
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7184744700479718581}
+  - component: {fileID: 98459815743958939}
+  - component: {fileID: 1611356938250716514}
+  m_Layer: 0
+  m_Name: Top Unit
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7184744700479718581
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5424969938168003667}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -4}
+  m_LocalScale: {x: 1, y: 1, z: 12}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2644236038539555071}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 174, y: -158}
+  m_SizeDelta: {x: 297.4, y: 311.9}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &98459815743958939
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5424969938168003667}
+  m_CullTransparentMesh: 1
+--- !u!114 &1611356938250716514
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5424969938168003667}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: kW
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+  m_sharedMaterial: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 48
+  m_fontSizeBase: 48
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: -10
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &6715313358049615057
 GameObject:
   m_ObjectHideFlags: 0
@@ -1133,6 +1270,141 @@ MonoBehaviour:
   m_characterSpacing: 0
   m_wordSpacing: 0
   m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6959371952034757116
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7960743205689609493}
+  - component: {fileID: 6331265187335467283}
+  - component: {fileID: 1391130928170133189}
+  m_Layer: 0
+  m_Name: Bottom Unit
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7960743205689609493
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6959371952034757116}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -11.999553}
+  m_LocalScale: {x: 1, y: 1, z: 12}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2644236038539555071}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 174, y: -316.00024}
+  m_SizeDelta: {x: 297.4, y: 311.9}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6331265187335467283
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6959371952034757116}
+  m_CullTransparentMesh: 1
+--- !u!114 &1391130928170133189
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6959371952034757116}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: kW
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+  m_sharedMaterial: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 48
+  m_fontSizeBase: 48
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: -10
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
@@ -1428,7 +1700,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.29411766, g: 0.29411766, b: 0.29411766, a: 1}
+  m_Color: {r: 0, g: 0.28627452, b: 0.48235294, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -1625,7 +1897,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 125, y: 0}
+  m_AnchoredPosition: {x: 12, y: 45}
   m_SizeDelta: {x: 94.42, y: 75}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5717530653220805111
@@ -1658,8 +1930,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 1F
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+  m_sharedMaterial: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2415,6 +2687,10 @@ PrefabInstance:
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967295
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -2529,6 +2805,10 @@ PrefabInstance:
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967295
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -2643,6 +2923,10 @@ PrefabInstance:
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967295
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -3007,6 +3291,10 @@ PrefabInstance:
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967295
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -3261,6 +3549,10 @@ PrefabInstance:
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967295
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -3375,6 +3667,10 @@ PrefabInstance:
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967295
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -3985,6 +4281,10 @@ PrefabInstance:
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967295
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -4989,6 +5289,10 @@ PrefabInstance:
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
+    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967295
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Prefabs/Power Management/Terminal Interface (Canvas).prefab
+++ b/Assets/Prefabs/Power Management/Terminal Interface (Canvas).prefab
@@ -804,8 +804,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4359153108576173765}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 33, z: 0}
-  m_LocalScale: {x: 12, y: 12, z: 12}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 4449442866253554669}
@@ -844,19 +844,16 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4513498784776264941}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000037252903}
-  m_LocalScale: {x: 0.8342354, y: 0.8342362, z: 0.8342355}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6076722063344693469}
-  - {fileID: 2469313201377118425}
-  - {fileID: 501136796324207651}
+  m_Children: []
   m_Father: {fileID: 3847105471395514049}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.000022649765, y: -2.7500045}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &349327983729259505
@@ -888,82 +885,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: 93e853238b0d802489355ccef5d90f18, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!1 &4830674739868983484
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2469313201377118425}
-  - component: {fileID: 2041725491409320882}
-  - component: {fileID: 5806649063809516677}
-  m_Layer: 0
-  m_Name: Locked Cover
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &2469313201377118425
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4830674739868983484}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4289679934156440139}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &2041725491409320882
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4830674739868983484}
-  m_CullTransparentMesh: 1
---- !u!114 &5806649063809516677
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4830674739868983484}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.39215687}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 950cde515103dd244a54c410b110d9c0, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1199,7 +1120,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 79.999565}
+  m_AnchoredPosition: {x: 0, y: 25}
   m_SizeDelta: {x: 452.57, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4623630707195014124
@@ -1230,7 +1151,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Selected Power Area:'
+  m_text: 'Area Name:'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
   m_sharedMaterial: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
@@ -1469,8 +1390,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -79.99971}
-  m_SizeDelta: {x: 1140.9, y: 50}
+  m_AnchoredPosition: {x: 0, y: -125}
+  m_SizeDelta: {x: 369.2, y: 147.66}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5204597664374537903
 CanvasRenderer:
@@ -1500,7 +1421,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: New Text
+  m_text: Residential
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
   m_sharedMaterial: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
@@ -1527,11 +1448,11 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 72
+  m_fontSize: 62.9
   m_fontSizeBase: 72
   m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 54
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 2
@@ -1593,8 +1514,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7113447675879857028}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 33, z: 0}
-  m_LocalScale: {x: 12, y: 12, z: 12}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 724600019390809946}
@@ -1845,7 +1766,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 154583c472c83e94b9f1ebbf5d0224aa, type: 2}
-  m_Color: {r: 0.8207547, g: 0.8207547, b: 0.8207547, a: 0.18431373}
+  m_Color: {r: 0.8207547, g: 0.8207547, b: 0.8207547, a: 0.12156863}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 0
@@ -1997,82 +1918,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &8668346482738287985
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6076722063344693469}
-  - component: {fileID: 5304317144109893833}
-  - component: {fileID: 4349671759448398501}
-  m_Layer: 0
-  m_Name: Powered Indicator
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &6076722063344693469
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8668346482738287985}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4289679934156440139}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5304317144109893833
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8668346482738287985}
-  m_CullTransparentMesh: 1
---- !u!114 &4349671759448398501
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8668346482738287985}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0.5882353, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 970cc06a7df9be74cb00b37af1344991, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1001 &380312106568894931
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2166,6 +2011,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Hangar
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: ZoneIndex
       value: 1
       objectReference: {fileID: 0}
@@ -2173,28 +2022,37 @@ PrefabInstance:
       propertyPath: _zoneIndex
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: deec335ada2d88744b0012f4e3827256, type: 3}
+      objectReference: {fileID: 21300000, guid: d3ce5199d9dfe5740b746e8a63371ce9, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: deec335ada2d88744b0012f4e3827256, type: 3}
+      objectReference: {fileID: 21300000, guid: d3ce5199d9dfe5740b746e8a63371ce9, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: deec335ada2d88744b0012f4e3827256, type: 3}
+      objectReference: {fileID: 21300000, guid: ddee973b7bda6dd4b826d04b43b96c57, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 30
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 1 - Power Button - Hangar
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3251438945388340261}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
 --- !u!224 &387097680508338720 stripped
@@ -2202,17 +2060,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
   m_PrefabInstance: {fileID: 380312106568894931}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2614753048518735146 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 380312106568894931}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &657916332874056373
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2306,6 +2153,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Cargo
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: ZoneIndex
       value: 2
       objectReference: {fileID: 0}
@@ -2313,16 +2164,37 @@ PrefabInstance:
       propertyPath: _zoneIndex
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
+    - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: d1b2ce4587ae8cd4b908433bedbc9805, type: 3}
+    - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: d1b2ce4587ae8cd4b908433bedbc9805, type: 3}
+    - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: a3ca226d16c7f75488c24859eb9b5db8, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -29
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -5
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 2- Power Button - Cargo
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2398999825750484098}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
 --- !u!224 &664703130979584326 stripped
@@ -2330,17 +2202,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
   m_PrefabInstance: {fileID: 657916332874056373}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2895595450619346508 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 657916332874056373}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &726864539081362601
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2434,508 +2295,50 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Command
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: _zoneIndex
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 26ef5e8b722b6d74486cef7f44319a6a, type: 3}
+      objectReference: {fileID: 21300000, guid: dbf3ebbc0eb2c9a499e2df1d9cfced36, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 26ef5e8b722b6d74486cef7f44319a6a, type: 3}
+      objectReference: {fileID: 21300000, guid: dbf3ebbc0eb2c9a499e2df1d9cfced36, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 26ef5e8b722b6d74486cef7f44319a6a, type: 3}
+      objectReference: {fileID: 21300000, guid: 2053ab2609c7a4641a132e635af54387, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -5
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 0 - Power Button - Command 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6020441423643633800}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
 --- !u!224 &724600019390809946 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
   m_PrefabInstance: {fileID: 726864539081362601}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &3105245831859548240 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 726864539081362601}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1001 &1219308912654018916
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 3871794077479332024}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -21
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -37.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 1489890424252932018}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &274182522050543892 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 1219308912654018916}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1572222674351715411
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4289679934156440139}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.01
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -1.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -21.77
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4294967295
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &501136796324207651 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 1572222674351715411}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1627806115061856232
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2311211455926084344}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -15.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -30
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 73559336652002802}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4294967295
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &410650526506295192 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 1627806115061856232}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1860795955287522912
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 7430486117852792957}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 19.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 5046323515436941175}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4294967295
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &790150270731490832 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 1860795955287522912}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2308954629075609867
 PrefabInstance:
@@ -3030,6 +2433,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Engineering
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: ZoneIndex
       value: 3
       objectReference: {fileID: 0}
@@ -3037,273 +2444,43 @@ PrefabInstance:
       propertyPath: _zoneIndex
       value: 3
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: bab3338e106d07542a8e9bcdf5db874e, type: 3}
+      objectReference: {fileID: 21300000, guid: 764ce15fffc981c49b4f5790e24ee345, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: bab3338e106d07542a8e9bcdf5db874e, type: 3}
+      objectReference: {fileID: 21300000, guid: 764ce15fffc981c49b4f5790e24ee345, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: bab3338e106d07542a8e9bcdf5db874e, type: 3}
+      objectReference: {fileID: 21300000, guid: 96099ba2e19a01841bb4bcdfc7241140, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -26.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -31
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 3- Power Button - Engineering
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 410650526506295192}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
---- !u!114 &73559336652002802 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 2308954629075609867}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &2311211455926084344 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
   m_PrefabInstance: {fileID: 2308954629075609867}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2657436782201073845
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2995776254783820929}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 19
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 614008940991570827}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &4018567525852944581 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 2657436782201073845}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2676253768807146688
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 8541110124373687948}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 1.4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 6313581749822474630}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4294967295
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &3892864814699547824 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 2676253768807146688}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2993554767008145266
 PrefabInstance:
@@ -3398,6 +2575,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Farms
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: ZoneIndex
       value: 10
       objectReference: {fileID: 0}
@@ -3405,281 +2586,43 @@ PrefabInstance:
       propertyPath: _zoneIndex
       value: 10
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: b3eaf6d5d76232842b47d80322605a76, type: 3}
+      objectReference: {fileID: 21300000, guid: 20692c73c21aed54b9069a101dc19ec9, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: b3eaf6d5d76232842b47d80322605a76, type: 3}
+      objectReference: {fileID: 21300000, guid: 20692c73c21aed54b9069a101dc19ec9, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: b3eaf6d5d76232842b47d80322605a76, type: 3}
+      objectReference: {fileID: 21300000, guid: b9716ea433ee9ff4ab4b4baa61af64ab, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 26
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -5
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 10 - Power Button - Farm
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4018567525852944581}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
---- !u!114 &614008940991570827 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 2993554767008145266}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &2995776254783820929 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
   m_PrefabInstance: {fileID: 2993554767008145266}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &3634185900689231090
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 664703130979584326}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -17.4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 2895595450619346508}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4294967295
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &2398999825750484098 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 3634185900689231090}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &3664730880905428945
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 7743487945028541263}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -30
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 5359320953014053957}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4294967295
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &2449518539565029281 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 3664730880905428945}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3865069939171779403
 PrefabInstance:
@@ -3774,6 +2717,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Community Center
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: ZoneIndex
       value: 8
       objectReference: {fileID: 0}
@@ -3781,265 +2728,43 @@ PrefabInstance:
       propertyPath: _zoneIndex
       value: 8
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 7378348665c8ef9408c8eb20f4b6b469, type: 3}
+      objectReference: {fileID: 21300000, guid: 6b58335be0d5325468e5cfdb7dc654b3, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 7378348665c8ef9408c8eb20f4b6b469, type: 3}
+      objectReference: {fileID: 21300000, guid: 6b58335be0d5325468e5cfdb7dc654b3, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 7378348665c8ef9408c8eb20f4b6b469, type: 3}
+      objectReference: {fileID: 21300000, guid: ba7dc99531eb4e7489416493bb4d02d5, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -25.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -41.25
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 8 - Power Button - Communal
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 274182522050543892}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
---- !u!114 &1489890424252932018 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 3865069939171779403}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &3871794077479332024 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
   m_PrefabInstance: {fileID: 3865069939171779403}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &4187984961678980467
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4449442866253554669}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 2065428156733953255}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &2971103970657426691 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 4187984961678980467}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &4280917973996008734
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 9120276197454691729}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -20
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 6883749419347036827}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &2904027107839024494 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 4280917973996008734}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4442664851347761182
 PrefabInstance:
@@ -4134,166 +2859,50 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Resident Hub
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: _zoneIndex
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 30616b4bfdd74e64983945e41b73729c, type: 3}
+      objectReference: {fileID: 21300000, guid: 4155df5e4c1fac74ca087e89782dd372, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 30616b4bfdd74e64983945e41b73729c, type: 3}
+      objectReference: {fileID: 21300000, guid: 4155df5e4c1fac74ca087e89782dd372, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 30616b4bfdd74e64983945e41b73729c, type: 3}
+      objectReference: {fileID: 21300000, guid: 845cd04f273ba744690fadce52fbb2e8, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -5
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 0 - Power Button - Command 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2971103970657426691}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
---- !u!114 &2065428156733953255 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 4442664851347761182}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &4449442866253554669 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
   m_PrefabInstance: {fileID: 4442664851347761182}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &4484075657662975061
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 387097680508338720}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 2614753048518735146}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4294967295
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &3251438945388340261 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 4484075657662975061}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4530110303378762984
 PrefabInstance:
@@ -4388,6 +2997,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Residential
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: ZoneIndex
       value: 7
       objectReference: {fileID: 0}
@@ -4395,375 +3008,43 @@ PrefabInstance:
       propertyPath: _zoneIndex
       value: 7
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 1e584e03517c9f241b7f0ede185ea79e, type: 3}
+      objectReference: {fileID: 21300000, guid: d96f3e1ff3e659245abf9ffdae9b45be, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 1e584e03517c9f241b7f0ede185ea79e, type: 3}
+      objectReference: {fileID: 21300000, guid: d96f3e1ff3e659245abf9ffdae9b45be, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 1e584e03517c9f241b7f0ede185ea79e, type: 3}
+      objectReference: {fileID: 21300000, guid: 76056ef2d4318b34f971cdf3c2ddeefc, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -31.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -5
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 7 - Power Button - Residential
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7478693192729846841}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
---- !u!114 &2292460312122593297 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 4530110303378762984}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &4523359789727115035 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
   m_PrefabInstance: {fileID: 4530110303378762984}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &4657843862336818198
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 7923010640677189214}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 5540121825032520020}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &6018551980125168742 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 4657843862336818198}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &4659302432580763896
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 724600019390809946}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 3105245831859548240}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &6020441423643633800 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 4659302432580763896}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &6966591494507010087
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 8823530468870680902}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 19
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -37.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 6585737611570611788}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &8325892914808713303 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 6966591494507010087}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7423761034132079502
 PrefabInstance:
@@ -4858,6 +3139,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Research
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: ZoneIndex
       value: 5
       objectReference: {fileID: 0}
@@ -4865,41 +3150,39 @@ PrefabInstance:
       propertyPath: _zoneIndex
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: a11ed763e1fbe65409a14d89fea77007, type: 3}
+      objectReference: {fileID: 21300000, guid: e21c22b13f3a3a042b6a4875a87e3b2b, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: a11ed763e1fbe65409a14d89fea77007, type: 3}
+      objectReference: {fileID: 21300000, guid: e21c22b13f3a3a042b6a4875a87e3b2b, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: a11ed763e1fbe65409a14d89fea77007, type: 3}
+      objectReference: {fileID: 21300000, guid: 2d7d8da01c5bebe41bcc19ed0e32ac2d, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 25.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -5
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 5- Power Button - Research
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 790150270731490832}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
---- !u!114 &5046323515436941175 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 7423761034132079502}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &7430486117852792957 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
@@ -4998,6 +3281,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Security
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: ZoneIndex
       value: 4
       objectReference: {fileID: 0}
@@ -5005,41 +3292,39 @@ PrefabInstance:
       propertyPath: _zoneIndex
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: ca9094024ff6f414f865b56ca7627d35, type: 3}
+      objectReference: {fileID: 21300000, guid: 950cde515103dd244a54c410b110d9c0, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: ca9094024ff6f414f865b56ca7627d35, type: 3}
+      objectReference: {fileID: 21300000, guid: 950cde515103dd244a54c410b110d9c0, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: ca9094024ff6f414f865b56ca7627d35, type: 3}
+      objectReference: {fileID: 21300000, guid: 2822a64dca01fe3458ef93961499daf5, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -20
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 4- Power Button - Security
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2449518539565029281}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
---- !u!114 &5359320953014053957 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 7741258747215876284}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &7743487945028541263 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
@@ -5138,6 +3423,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Hangar
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: ZoneIndex
       value: 1
       objectReference: {fileID: 0}
@@ -5145,163 +3434,43 @@ PrefabInstance:
       propertyPath: _zoneIndex
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: deec335ada2d88744b0012f4e3827256, type: 3}
+      objectReference: {fileID: 21300000, guid: 9ea186022547dff4d93940abeca9560f, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: deec335ada2d88744b0012f4e3827256, type: 3}
+      objectReference: {fileID: 21300000, guid: 9ea186022547dff4d93940abeca9560f, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: deec335ada2d88744b0012f4e3827256, type: 3}
+      objectReference: {fileID: 21300000, guid: ddee973b7bda6dd4b826d04b43b96c57, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 30
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 1 - Power Button - Hangar
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6018551980125168742}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
---- !u!114 &5540121825032520020 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 7920754917708807597}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &7923010640677189214 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
   m_PrefabInstance: {fileID: 7920754917708807597}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &8128789619388120663
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 8223416709738453974}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 17.05
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -37.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 5983373695987428572}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4294967295
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &7199723517972485671 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 8128789619388120663}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8216656437862649893
 PrefabInstance:
@@ -5396,6 +3565,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Nuclear Generator
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: ZoneIndex
       value: 6
       objectReference: {fileID: 0}
@@ -5403,155 +3576,43 @@ PrefabInstance:
       propertyPath: _zoneIndex
       value: 6
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 6ec8d808be1e30c4588a26d90cc37053, type: 3}
+      objectReference: {fileID: 21300000, guid: d812a453b0970644fbd00d72398e376c, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 6ec8d808be1e30c4588a26d90cc37053, type: 3}
+      objectReference: {fileID: 21300000, guid: d812a453b0970644fbd00d72398e376c, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 6ec8d808be1e30c4588a26d90cc37053, type: 3}
+      objectReference: {fileID: 21300000, guid: 0b764101742383d45987a6a6e1040800, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -40
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 6- Power Button - Nuclear
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7199723517972485671}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
---- !u!114 &5983373695987428572 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 8216656437862649893}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &8223416709738453974 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
   m_PrefabInstance: {fileID: 8216656437862649893}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &8425226264713825353
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4523359789727115035}
-    m_Modifications:
-    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Name
-      value: ZoneConsumptionDisplay
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -21
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-      propertyPath: _zone
-      value: 
-      objectReference: {fileID: 2292460312122593297}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
---- !u!224 &7478693192729846841 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
-  m_PrefabInstance: {fileID: 8425226264713825353}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8543331745838871935
 PrefabInstance:
@@ -5646,44 +3707,46 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Station Concourse
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: _zoneIndex
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 26ef5e8b722b6d74486cef7f44319a6a, type: 3}
+      objectReference: {fileID: 21300000, guid: a1181f6cda747224398bf379a2e77dd0, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 26ef5e8b722b6d74486cef7f44319a6a, type: 3}
+      objectReference: {fileID: 21300000, guid: a1181f6cda747224398bf379a2e77dd0, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 26ef5e8b722b6d74486cef7f44319a6a, type: 3}
+      objectReference: {fileID: 21300000, guid: d17929d0fa97cec4aa9663d7ec35eebd, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -5
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 0 - Power Button - Command 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3892864814699547824}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
---- !u!114 &6313581749822474630 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 8543331745838871935}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &8541110124373687948 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
@@ -5782,6 +3845,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Medical Bay
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: ZoneIndex
       value: 11
       objectReference: {fileID: 0}
@@ -5789,41 +3856,39 @@ PrefabInstance:
       propertyPath: _zoneIndex
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: c0711cc7e3d9f324d97991e03a0b1749, type: 3}
+      objectReference: {fileID: 21300000, guid: 77b3a646160ebd048b06e192759fb1d0, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: c0711cc7e3d9f324d97991e03a0b1749, type: 3}
+      objectReference: {fileID: 21300000, guid: 77b3a646160ebd048b06e192759fb1d0, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: c0711cc7e3d9f324d97991e03a0b1749, type: 3}
+      objectReference: {fileID: 21300000, guid: 49d53478b27a3da41afbb117e7a5e443, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 20.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -41.25
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 11 - Power Button - Medical
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8325892914808713303}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
---- !u!114 &6585737611570611788 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 8821257153153956533}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &8823530468870680902 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
@@ -5922,6 +3987,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: ZoneName
+      value: Admin
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: ZoneIndex
       value: 9
       objectReference: {fileID: 0}
@@ -5929,41 +3998,39 @@ PrefabInstance:
       propertyPath: _zoneIndex
       value: 9
       objectReference: {fileID: 0}
+    - target: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: _zoneNameText
+      value: 
+      objectReference: {fileID: 6993535887247295236}
     - target: {fileID: 2684315969942265932, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 9359c480d07c7dd48ac723887f8e20e7, type: 3}
+      objectReference: {fileID: 21300000, guid: 9187c16286da6ec40b22ee8d6e0bc3ee, type: 3}
     - target: {fileID: 3782294193909620045, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 9359c480d07c7dd48ac723887f8e20e7, type: 3}
+      objectReference: {fileID: 21300000, guid: 9187c16286da6ec40b22ee8d6e0bc3ee, type: 3}
     - target: {fileID: 4051290977471355720, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 9359c480d07c7dd48ac723887f8e20e7, type: 3}
+      objectReference: {fileID: 21300000, guid: e5bd818b55d70e54f8dc8a6ddf125d06, type: 3}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653970045070981583, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -20
+      objectReference: {fileID: 0}
     - target: {fileID: 5635867508123537812, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
       propertyPath: m_Name
       value: 9 - Power Button - Offices
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2904027107839024494}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
---- !u!114 &6883749419347036827 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2381942218069245177, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}
-  m_PrefabInstance: {fileID: 9118001936820254306}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322a3aafdac5d3e489607af772060748, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &9120276197454691729 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6786815310826483, guid: d89384928e9bf2b40afb53b4ce8e2136, type: 3}

--- a/Assets/Prefabs/Power Management/Terminal.prefab
+++ b/Assets/Prefabs/Power Management/Terminal.prefab
@@ -441,6 +441,7 @@ MonoBehaviour:
   _terminalAnim: {fileID: 7018956463221943584}
   _terminalCam: {fileID: 1505027545462987630}
   _puzzleCam: {fileID: 3280611248902691037}
+  _bootUpAnim: {fileID: 6695816375632120212}
 --- !u!1 &4709314610774902048
 GameObject:
   m_ObjectHideFlags: 0
@@ -7946,6 +7947,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
+--- !u!95 &6695816375632120212 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 7395685878779699750, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
+  m_PrefabInstance: {fileID: 4201454501766540210}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &8555384465466071134 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5545132134957757420, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}

--- a/Assets/Prefabs/Power Management/Terminal.prefab
+++ b/Assets/Prefabs/Power Management/Terminal.prefab
@@ -324,7 +324,7 @@ Transform:
   - {fileID: 4539339306175569260}
   - {fileID: 3981230310418274719}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &274923484696418617
 MonoBehaviour:
@@ -8833,7 +8833,7 @@ PrefabInstance:
       objectReference: {fileID: 21300000, guid: 2d7d8da01c5bebe41bcc19ed0e32ac2d, type: 3}
     - target: {fileID: 6883749419347036827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: ZoneName
-      value: Adminstration
+      value: Admin
       objectReference: {fileID: 0}
     - target: {fileID: 6883749419347036827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal

--- a/Assets/Prefabs/Power Management/Terminal.prefab
+++ b/Assets/Prefabs/Power Management/Terminal.prefab
@@ -866,141 +866,6 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
---- !u!1 &6546605966423200334
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6067665223236019879}
-  - component: {fileID: 7895862101714918049}
-  - component: {fileID: 2954601798635179383}
-  m_Layer: 0
-  m_Name: Bottom Unit
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &6067665223236019879
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6546605966423200334}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -11.999553}
-  m_LocalScale: {x: 1, y: 1, z: 12}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2232842245704063821}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 174, y: -316.00024}
-  m_SizeDelta: {x: 297.4, y: 311.9}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &7895862101714918049
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6546605966423200334}
-  m_CullTransparentMesh: 1
---- !u!114 &2954601798635179383
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6546605966423200334}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: kW
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-  m_sharedMaterial: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 48
-  m_fontSizeBase: 48
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: -10
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &7426202197799490410
 GameObject:
   m_ObjectHideFlags: 0
@@ -5945,141 +5810,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &8144704887912896481
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6483995608405536519}
-  - component: {fileID: 4256847458381005865}
-  - component: {fileID: 3175635884423327440}
-  m_Layer: 0
-  m_Name: Top Unit
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &6483995608405536519
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8144704887912896481}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -4}
-  m_LocalScale: {x: 1, y: 1, z: 12}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2232842245704063821}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 174, y: -158}
-  m_SizeDelta: {x: 297.4, y: 311.9}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &4256847458381005865
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8144704887912896481}
-  m_CullTransparentMesh: 1
---- !u!114 &3175635884423327440
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8144704887912896481}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: kW
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-  m_sharedMaterial: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 48
-  m_fontSizeBase: 48
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: -10
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &8266506315432899394
 GameObject:
   m_ObjectHideFlags: 0
@@ -7545,10 +7275,6 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 6b58335be0d5325468e5cfdb7dc654b3, type: 3}
-    - target: {fileID: 213092760071700422, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 1548
-      objectReference: {fileID: 0}
     - target: {fileID: 230156196931535051, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -7601,26 +7327,6 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 76056ef2d4318b34f971cdf3c2ddeefc, type: 3}
-    - target: {fileID: 545730424823536159, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 551523809765381240, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Color.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 551523809765381240, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Color.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 551523809765381240, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Color.r
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 605837125309547029, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 614008940991570827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: ZoneName
       value: Farms
@@ -7644,14 +7350,6 @@ PrefabInstance:
     - target: {fileID: 617043332019369234, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 637032467342853900, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 637032467342853900, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 160
       objectReference: {fileID: 0}
     - target: {fileID: 710140077307802963, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_Sprite
@@ -7678,10 +7376,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 897040354772679109, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 912280372467793325, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
@@ -7781,26 +7475,10 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1676443391868631310, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 1743488637253153347, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 96099ba2e19a01841bb4bcdfc7241140, type: 3}
-    - target: {fileID: 1773591348723365105, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Color.b
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 1773591348723365105, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Color.g
-      value: 0.28627452
-      objectReference: {fileID: 0}
-    - target: {fileID: 1773591348723365105, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Color.r
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 1776251118794795825, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -7869,14 +7547,6 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2290841359326280714, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_fontAsset
-      value: 
-      objectReference: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 2290841359326280714, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
     - target: {fileID: 2292460312122593297, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: ZoneName
       value: Residential
@@ -7920,10 +7590,6 @@ PrefabInstance:
     - target: {fileID: 2398999825750484098, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -4.71
-      objectReference: {fileID: 0}
-    - target: {fileID: 2441103530201522865, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2449518539565029281, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8117,26 +7783,6 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3847105471395514049, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 3847105471395514049, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 3847105471395514049, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 3847105471395514049, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3847105471395514049, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0
-      objectReference: {fileID: 0}
     - target: {fileID: 3860626255472930706, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -8186,10 +7832,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4163059710694027061, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4163352001405745557, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
@@ -8249,18 +7891,6 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: ddee973b7bda6dd4b826d04b43b96c57, type: 3}
-    - target: {fileID: 4449969880581110311, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Color.b
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 4449969880581110311, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Color.g
-      value: 0.28627452
-      objectReference: {fileID: 0}
-    - target: {fileID: 4449969880581110311, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Color.r
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4497758977911984612, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -8288,10 +7918,6 @@ PrefabInstance:
     - target: {fileID: 4909144394027457853, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4923218555662689928, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_PresetInfoIsWorld
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4932014228315758804, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_sharedMaterial
@@ -8341,22 +7967,6 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: e5bd818b55d70e54f8dc8a6ddf125d06, type: 3}
-    - target: {fileID: 5107812771559637904, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_text
-      value: 'Available Power:'
-      objectReference: {fileID: 0}
-    - target: {fileID: 5107812771559637904, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_fontAsset
-      value: 
-      objectReference: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 5107812771559637904, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 5107812771559637904, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_HorizontalAlignment
-      value: 2
-      objectReference: {fileID: 0}
     - target: {fileID: 5122841037990810401, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -8364,14 +7974,6 @@ PrefabInstance:
     - target: {fileID: 5140920140653341932, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5169553711103382755, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -4
-      objectReference: {fileID: 0}
-    - target: {fileID: 5169553711103382755, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -79
       objectReference: {fileID: 0}
     - target: {fileID: 5170466033432905381, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
@@ -8445,18 +8047,6 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5491987785285182497, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 176
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520431900549413507, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520431900549413507, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -115
-      objectReference: {fileID: 0}
     - target: {fileID: 5540121825032520020, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: ZoneName
       value: Hangar
@@ -8512,10 +8102,6 @@ PrefabInstance:
     - target: {fileID: 5545132134957757420, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_SizeDelta.y
       value: 1080
-      objectReference: {fileID: 0}
-    - target: {fileID: 5545132134957757420, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.00049999997
       objectReference: {fileID: 0}
     - target: {fileID: 5545132134957757420, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8604,18 +8190,6 @@ PrefabInstance:
     - target: {fileID: 5718673380491044793, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5848760393630308144, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5848760393630308144, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 5848760393630308144, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 43
       objectReference: {fileID: 0}
     - target: {fileID: 5929174945405710256, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_fontAsset
@@ -8708,18 +8282,6 @@ PrefabInstance:
     - target: {fileID: 6126426625347959605, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6142981921842812293, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.9998474
-      objectReference: {fileID: 0}
-    - target: {fileID: 6142981921842812293, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0.06109497
-      objectReference: {fileID: 0}
-    - target: {fileID: 6142981921842812293, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -103.99962
       objectReference: {fileID: 0}
     - target: {fileID: 6184918985631000293, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_Sprite
@@ -8955,10 +8517,6 @@ PrefabInstance:
       propertyPath: m_AdditionalShaderChannelsFlag
       value: 25
       objectReference: {fileID: 0}
-    - target: {fileID: 8144113264594480964, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 8163316204138787596, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -8999,10 +8557,6 @@ PrefabInstance:
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8414884080645196745, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 8503980728763049865, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_fontAsset
       value: 
@@ -9015,20 +8569,6 @@ PrefabInstance:
       propertyPath: m_fontColor32.rgba
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: 8584871779215987811, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_text
-      value: '100
-
-        200'
-      objectReference: {fileID: 0}
-    - target: {fileID: 8584871779215987811, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_fontAsset
-      value: 
-      objectReference: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 8584871779215987811, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
     - target: {fileID: 8627886264831772276, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -9102,13 +8642,7 @@ PrefabInstance:
     - {fileID: 2133844431896245766, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
     - {fileID: 4830674739868983484, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
     - {fileID: 8668346482738287985, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 2644236038539555071, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6483995608405536519}
-    - targetCorrespondingSourceObject: {fileID: 2644236038539555071, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6067665223236019879}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
 --- !u!1 &654009355215313208 stripped
@@ -9148,11 +8682,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &2232842245704063821 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2644236038539555071, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3031705332402898308 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1178913358264069686, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}

--- a/Assets/Prefabs/Power Management/Terminal.prefab
+++ b/Assets/Prefabs/Power Management/Terminal.prefab
@@ -7235,30 +7235,14 @@ PrefabInstance:
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 70974025231114114, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 73559336652002802, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Engineering
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 73559336652002802, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 73559336652002802, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 73559336652002802, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 8019749944805986439}
-    - target: {fileID: 73559336652002802, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 5497388751266171963}
     - target: {fileID: 112530242003913006, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_Name
       value: Terminal Interface (Canvas)
@@ -7271,10 +7255,6 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 134567192784977414, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 6b58335be0d5325468e5cfdb7dc654b3, type: 3}
     - target: {fileID: 230156196931535051, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -7295,22 +7275,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -41.28
       objectReference: {fileID: 0}
-    - target: {fileID: 281795261550133191, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Color.a
-      value: 0.12156863
-      objectReference: {fileID: 0}
-    - target: {fileID: 318429518280784600, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 381562590223567175, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 764ce15fffc981c49b4f5790e24ee345, type: 3}
-    - target: {fileID: 404927631333438294, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 845cd04f273ba744690fadce52fbb2e8, type: 3}
     - target: {fileID: 410650526506295192, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0
@@ -7319,46 +7283,14 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.x
       value: -26.81
       objectReference: {fileID: 0}
-    - target: {fileID: 482224255142492107, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 497433337612646304, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 76056ef2d4318b34f971cdf3c2ddeefc, type: 3}
     - target: {fileID: 614008940991570827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Farms
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 614008940991570827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 614008940991570827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 614008940991570827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 6718769968915159002}
-    - target: {fileID: 614008940991570827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 9096312836680600422}
-    - target: {fileID: 617043332019369234, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 710140077307802963, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 4155df5e4c1fac74ca087e89782dd372, type: 3}
-    - target: {fileID: 766535347813953957, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: d96f3e1ff3e659245abf9ffdae9b45be, type: 3}
     - target: {fileID: 790150270731490832, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.1
@@ -7375,42 +7307,6 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 897040354772679109, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 922012055024942910, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 20692c73c21aed54b9069a101dc19ec9, type: 3}
-    - target: {fileID: 980217967808821251, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: ba7dc99531eb4e7489416493bb4d02d5, type: 3}
-    - target: {fileID: 994283519263766632, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1059978562128706718, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1105767137368124158, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 369.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1105767137368124158, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 147.66
-      objectReference: {fileID: 0}
-    - target: {fileID: 1105767137368124158, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1105767137368124158, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -123
-      objectReference: {fileID: 0}
     - target: {fileID: 1178913358264069686, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_fontAsset
       value: 
@@ -7423,75 +7319,27 @@ PrefabInstance:
       propertyPath: m_fontColor32.rgba
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: 1217070890136552199, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 6b58335be0d5325468e5cfdb7dc654b3, type: 3}
     - target: {fileID: 1269935974372604981, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1275131804866462778, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: b9716ea433ee9ff4ab4b4baa61af64ab, type: 3}
     - target: {fileID: 1331922124622634407, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1376208979319602571, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1474478661717128262, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 764ce15fffc981c49b4f5790e24ee345, type: 3}
     - target: {fileID: 1477038587731450920, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
     - target: {fileID: 1489890424252932018, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Community Center
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 1489890424252932018, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 1489890424252932018, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 1489890424252932018, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 7581559159050669579}
-    - target: {fileID: 1489890424252932018, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 5347564988187759287}
-    - target: {fileID: 1584480175238712361, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1743488637253153347, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 96099ba2e19a01841bb4bcdfc7241140, type: 3}
     - target: {fileID: 1776251118794795825, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1794437078266890322, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 4155df5e4c1fac74ca087e89782dd372, type: 3}
-    - target: {fileID: 1843435492086177563, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1916693911979756530, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
@@ -7499,38 +7347,18 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1990226507723394212, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: d96f3e1ff3e659245abf9ffdae9b45be, type: 3}
     - target: {fileID: 2065428156733953255, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Resident Hub
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 2065428156733953255, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 2065428156733953255, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 2065428156733953255, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 4882596054889615900}
-    - target: {fileID: 2065428156733953255, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 6972472563767643808}
     - target: {fileID: 2107175671640921135, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2159008405135802943, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 20692c73c21aed54b9069a101dc19ec9, type: 3}
     - target: {fileID: 2211323672357598419, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
@@ -7543,34 +7371,14 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2240373282184557066, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2292460312122593297, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Residential
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 2292460312122593297, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 2292460312122593297, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 2292460312122593297, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 950448337539689254}
-    - target: {fileID: 2292460312122593297, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 3328703691267356570}
-    - target: {fileID: 2308016741596326303, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: d3ce5199d9dfe5740b746e8a63371ce9, type: 3}
     - target: {fileID: 2319609116791266423, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_sharedMaterial
       value: 
@@ -7607,61 +7415,25 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2583574160645598265, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2614753048518735146, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Hangar
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 2614753048518735146, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 2614753048518735146, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 2614753048518735146, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 5180936248706771770}
-    - target: {fileID: 2614753048518735146, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 7270824057924286342}
-    - target: {fileID: 2691154162052137256, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2895595450619346508, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Cargo
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 2895595450619346508, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 2895595450619346508, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 2895595450619346508, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 5454978238960266141}
-    - target: {fileID: 2895595450619346508, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 7544299217433016097}
     - target: {fileID: 2904027107839024494, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -1.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 2968119478485439002, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2971103970657426691, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_LocalPosition.z
@@ -7680,37 +7452,13 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 274923484696418617}
     - target: {fileID: 3105245831859548240, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Command
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 3105245831859548240, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 3105245831859548240, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 3105245831859548240, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 4140474901342578583}
-    - target: {fileID: 3105245831859548240, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 1906339962653883179}
-    - target: {fileID: 3198110217014600441, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: d1b2ce4587ae8cd4b908433bedbc9805, type: 3}
-    - target: {fileID: 3198520606107971113, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3198520606107971113, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 20
-      objectReference: {fileID: 0}
     - target: {fileID: 3219023329754378976, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -7723,14 +7471,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 29.8
       objectReference: {fileID: 0}
-    - target: {fileID: 3273745956249429653, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3353746369997440775, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 3376728225804338834, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
@@ -7739,34 +7479,14 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3411138435213487333, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: dbf3ebbc0eb2c9a499e2df1d9cfced36, type: 3}
-    - target: {fileID: 3512589803103201270, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 3513353226976302809, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3537701505841633789, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: a3ca226d16c7f75488c24859eb9b5db8, type: 3}
-    - target: {fileID: 3547230528569644190, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: d3ce5199d9dfe5740b746e8a63371ce9, type: 3}
     - target: {fileID: 3582514755118913204, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3616184752822360033, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 2053ab2609c7a4641a132e635af54387, type: 3}
     - target: {fileID: 3626503978518263590, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -7779,33 +7499,13 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3773445874366278433, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 3860626255472930706, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3892864814699547824, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -1.57
-      objectReference: {fileID: 0}
-    - target: {fileID: 3892864814699547824, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -4.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 3915153230049729875, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3924881612682612224, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3965201075906041064, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_text
-      value: 'Area Name:'
       objectReference: {fileID: 0}
     - target: {fileID: 3998698535790526612, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
@@ -7819,14 +7519,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -5.69
       objectReference: {fileID: 0}
-    - target: {fileID: 4082123105551885547, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4108443620074477609, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4139561513889127446, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -7839,142 +7531,26 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4193743701138560565, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4221813851329871236, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4289679934156440139, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4289679934156440139, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4289679934156440139, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4289679934156440139, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4289679934156440139, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4289679934156440139, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4337514944634569137, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4359153108576173765, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4359153108576173765, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4421422046318403576, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: d1b2ce4587ae8cd4b908433bedbc9805, type: 3}
-    - target: {fileID: 4431032364163732123, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: ddee973b7bda6dd4b826d04b43b96c57, type: 3}
-    - target: {fileID: 4497758977911984612, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: dbf3ebbc0eb2c9a499e2df1d9cfced36, type: 3}
     - target: {fileID: 4520911939567722722, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 4689696063974360229, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4775755645591053250, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: e21c22b13f3a3a042b6a4875a87e3b2b, type: 3}
-    - target: {fileID: 4779010836778820093, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 49d53478b27a3da41afbb117e7a5e443, type: 3}
-    - target: {fileID: 4822627818087802930, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: a1181f6cda747224398bf379a2e77dd0, type: 3}
-    - target: {fileID: 4909144394027457853, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4932014228315758804, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 5008647319911703039, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5021763159216944289, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_fontAsset
-      value: 
-      objectReference: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 5021763159216944289, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 5021763159216944289, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4294967295
-      objectReference: {fileID: 0}
     - target: {fileID: 5046323515436941175, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Research
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 5046323515436941175, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 5046323515436941175, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 5046323515436941175, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 6921506046804728079}
-    - target: {fileID: 5046323515436941175, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 4832191937856390579}
-    - target: {fileID: 5078378095547485544, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: d812a453b0970644fbd00d72398e376c, type: 3}
-    - target: {fileID: 5093771144189865258, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: e5bd818b55d70e54f8dc8a6ddf125d06, type: 3}
-    - target: {fileID: 5122841037990810401, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5140920140653341932, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 5170466033432905381, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
@@ -7983,10 +7559,6 @@ PrefabInstance:
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 5236762256026836449, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 9ea186022547dff4d93940abeca9560f, type: 3}
     - target: {fileID: 5252449397295645357, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -7999,38 +7571,14 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5294313838875438645, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5349852851895405421, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 0b764101742383d45987a6a6e1040800, type: 3}
     - target: {fileID: 5359320953014053957, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Security
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 5359320953014053957, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 5359320953014053957, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 5359320953014053957, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 5406426551143323838}
-    - target: {fileID: 5359320953014053957, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 7495742028048696322}
-    - target: {fileID: 5401169402127182639, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 9187c16286da6ec40b22ee8d6e0bc3ee, type: 3}
     - target: {fileID: 5404384364772451135, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -8039,34 +7587,14 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5436333465858431047, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5486902020682982223, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 5540121825032520020, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Hangar
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 5540121825032520020, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 5540121825032520020, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 5540121825032520020, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 4143097581334375289}
-    - target: {fileID: 5540121825032520020, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 1909095956576171973}
     - target: {fileID: 5545132134957757420, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -8151,46 +7679,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 180
       objectReference: {fileID: 0}
-    - target: {fileID: 5592325826838864610, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5626700329645778936, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 77b3a646160ebd048b06e192759fb1d0, type: 3}
-    - target: {fileID: 5633689737649795312, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 950cde515103dd244a54c410b110d9c0, type: 3}
-    - target: {fileID: 5668080678846590519, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: d17929d0fa97cec4aa9663d7ec35eebd, type: 3}
-    - target: {fileID: 5684525526325872765, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 5684525526325872765, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 5684525526325872765, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 5684525526325872765, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 5690321800990118305, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 5718673380491044793, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 5929174945405710256, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_fontAsset
       value: 
@@ -8202,10 +7694,6 @@ PrefabInstance:
     - target: {fileID: 5929174945405710256, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_fontColor32.rgba
       value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 5976352574282884780, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5979703545498737811, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_fontAsset
@@ -8220,37 +7708,17 @@ PrefabInstance:
       value: 4294967295
       objectReference: {fileID: 0}
     - target: {fileID: 5983373695987428572, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Nuclear Generator
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 5983373695987428572, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 5983373695987428572, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 5983373695987428572, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 654009355215313208}
-    - target: {fileID: 5983373695987428572, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 3031705332402898308}
-    - target: {fileID: 6005385713894083572, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 2822a64dca01fe3458ef93961499daf5, type: 3}
     - target: {fileID: 6014992129323017657, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6015427927671643843, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: e21c22b13f3a3a042b6a4875a87e3b2b, type: 3}
     - target: {fileID: 6018551980125168742, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -1.1
@@ -8271,54 +7739,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -4.9
       objectReference: {fileID: 0}
-    - target: {fileID: 6039496229008315699, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: a1181f6cda747224398bf379a2e77dd0, type: 3}
-    - target: {fileID: 6058528515724400398, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 6126426625347959605, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6184918985631000293, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: ddee973b7bda6dd4b826d04b43b96c57, type: 3}
-    - target: {fileID: 6289266262756028521, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: d812a453b0970644fbd00d72398e376c, type: 3}
     - target: {fileID: 6313581749822474630, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Station Concourse
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 6313581749822474630, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 6313581749822474630, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 6313581749822474630, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 6701135808585925551}
-    - target: {fileID: 6313581749822474630, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 9222934874925981459}
-    - target: {fileID: 6376025146493731900, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6454014671517606112, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 9ea186022547dff4d93940abeca9560f, type: 3}
     - target: {fileID: 6503393059651269309, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
@@ -8328,33 +7760,13 @@ PrefabInstance:
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
     - target: {fileID: 6585737611570611788, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Medical Bay
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 6585737611570611788, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 6585737611570611788, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 6585737611570611788, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 1833685304318361416}
-    - target: {fileID: 6585737611570611788, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 4211933231770215412}
-    - target: {fileID: 6588895120255766741, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6613884962048284206, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 9187c16286da6ec40b22ee8d6e0bc3ee, type: 3}
     - target: {fileID: 6628159919853266303, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_text
       value: '105
@@ -8377,70 +7789,22 @@ PrefabInstance:
       propertyPath: m_fontColor32.rgba
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: 6845018880271821101, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6850838525234990577, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 950cde515103dd244a54c410b110d9c0, type: 3}
-    - target: {fileID: 6857853599960816377, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 77b3a646160ebd048b06e192759fb1d0, type: 3}
-    - target: {fileID: 6863324195333904582, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 2d7d8da01c5bebe41bcc19ed0e32ac2d, type: 3}
     - target: {fileID: 6883749419347036827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: ZoneName
-      value: Admin
-      objectReference: {fileID: 0}
+      propertyPath: Terminal
+      value: 
+      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 6883749419347036827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 6883749419347036827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _zoneNameText
-      value: 
-      objectReference: {fileID: 6575421816797456566}
-    - target: {fileID: 6883749419347036827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayBar
-      value: 
-      objectReference: {fileID: 4806503172027388529}
-    - target: {fileID: 6883749419347036827, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _consumptionDisplayText
-      value: 
-      objectReference: {fileID: 7040644435043372749}
     - target: {fileID: 6929188751040246928, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 6993535887247295236, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_text
-      value: Residential
-      objectReference: {fileID: 0}
-    - target: {fileID: 6993535887247295236, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_fontSize
-      value: 62.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 6993535887247295236, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_fontSizeMin
-      value: 54
-      objectReference: {fileID: 0}
-    - target: {fileID: 6993535887247295236, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_enableAutoSizing
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 7104287938954230712, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 7113447675879857028, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 7199723517972485671, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.1
@@ -8461,15 +7825,7 @@ PrefabInstance:
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 7399879386073704477, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 7454386657471675496, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7475308597458243302, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
@@ -8497,10 +7853,6 @@ PrefabInstance:
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 7943665447056259231, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 8048553594345556761, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: _terminal
       value: 
@@ -8509,10 +7861,6 @@ PrefabInstance:
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-    - target: {fileID: 8135947283308281212, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 8137595406766204647, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_AdditionalShaderChannelsFlag
       value: 25
@@ -8537,26 +7885,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -40.9
       objectReference: {fileID: 0}
-    - target: {fileID: 8327467455143016842, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8387604156947767207, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 8387604156947767207, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 8387604156947767207, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 8387604156947767207, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 8503980728763049865, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_fontAsset
       value: 
@@ -8569,15 +7897,7 @@ PrefabInstance:
       propertyPath: m_fontColor32.rgba
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: 8627886264831772276, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 8683532797795662850, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8713652132631347982, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
@@ -8605,29 +7925,13 @@ PrefabInstance:
       propertyPath: _terminal
       value: 
       objectReference: {fileID: 274923484696418617}
-    - target: {fileID: 8876658529395825669, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: _terminal
-      value: 
-      objectReference: {fileID: 274923484696418617}
     - target: {fileID: 8891885796797848976, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8905273439187727071, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8924490054415813906, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8980514810049170972, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9019191620812485863, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 9054753727123947656, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
       propertyPath: m_StaticEditorFlags
@@ -8638,269 +7942,15 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 2133844431896245766, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-    - {fileID: 4830674739868983484, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-    - {fileID: 8668346482738287985, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
+    m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
---- !u!1 &654009355215313208 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3701134881886483082, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &950448337539689254 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3998698535790526612, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1833685304318361416 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2538938968645129466, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1906339962653883179 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2322237292017553561, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1909095956576171973 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2319609116791266423, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &3031705332402898308 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1178913358264069686, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &3328703691267356570 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1477038587731450920, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &4140474901342578583 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 232915490772831269, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &4143097581334375289 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 230156196931535051, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &4211933231770215412 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 17269404430567494, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &4806503172027388529 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8717475401048897987, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &4832191937856390579 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8737533500186258945, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &4882596054889615900 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8758630074483866030, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &5180936248706771770 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 9054753727123947656, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &5347564988187759287 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8104454706446596357, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &5406426551143323838 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8163316204138787596, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &5454978238960266141 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8213837111660691503, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &5497388751266171963 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8503980728763049865, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &6575421816797456566 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6993535887247295236, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &6701135808585925551 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7399879386073704477, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &6718769968915159002 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7454386657471675496, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &6921506046804728079 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6503393059651269309, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6972472563767643808 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6525049835392181522, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &7040644435043372749 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6628159919853266303, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &7270824057924286342 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6821184796408044596, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &7495742028048696322 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5929174945405710256, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &7544299217433016097 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5979703545498737811, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &7581559159050669579 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6014992129323017657, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &8019749944805986439 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6126426625347959605, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &8555384465466071134 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5545132134957757420, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
   m_PrefabInstance: {fileID: 4201454501766540210}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &9096312836680600422 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4932014228315758804, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &9222934874925981459 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5021763159216944289, guid: bbac9b5b1cd1b054f991eecf57094029, type: 3}
-  m_PrefabInstance: {fileID: 4201454501766540210}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &7799574342524428230
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Power Management/UI/Power Toggle.prefab
+++ b/Assets/Prefabs/Power Management/UI/Power Toggle.prefab
@@ -112,6 +112,7 @@ RectTransform:
   m_Children:
   - {fileID: 3923158649237384773}
   - {fileID: 8610255161339511593}
+  - {fileID: 4653970045070981583}
   m_Father: {fileID: 0}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -134,13 +135,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ZoneIndex: 0
   ZoneName: 
-  _terminal: {fileID: 0}
+  Terminal: {fileID: 0}
   _toggle: {fileID: 5114440192269925841}
   _lockedIndicator: {fileID: 8285298406710366119}
   _poweredIndicator: {fileID: 3680083860781503616}
   _zoneNameText: {fileID: 0}
-  _consumptionDisplayText: {fileID: 0}
-  _consumptionDisplayBar: {fileID: 0}
+  _consumptionDisplayText: {fileID: 3684190828580815326}
+  _consumptionDisplayBar: {fileID: 1162392617215040866}
 --- !u!222 &2452488438754748412
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -373,3 +374,129 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1001 &6031433065430503871
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6786815310826483}
+    m_Modifications:
+    - target: {fileID: 598231107054502485, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_Name
+      value: ZoneConsumptionDisplay
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 1.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6778989984727218373, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+      propertyPath: _zone
+      value: 
+      objectReference: {fileID: 2381942218069245177}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+--- !u!1 &1162392617215040866 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4869043791583268061, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+  m_PrefabInstance: {fileID: 6031433065430503871}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3684190828580815326 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6958928265487061089, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+  m_PrefabInstance: {fileID: 6031433065430503871}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &4653970045070981583 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1379734758493546608, guid: b58ca4b511bcbac46ac9cbe27c01ccd9, type: 3}
+  m_PrefabInstance: {fileID: 6031433065430503871}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Power Management/UI/Power Toggle.prefab
+++ b/Assets/Prefabs/Power Management/UI/Power Toggle.prefab
@@ -142,6 +142,9 @@ MonoBehaviour:
   _zoneNameText: {fileID: 0}
   _consumptionDisplayText: {fileID: 3684190828580815326}
   _consumptionDisplayBar: {fileID: 1162392617215040866}
+  _flashingInterval: 0.15
+  _flashingColor: {r: 0.735849, g: 0.17007832, b: 0.17007832, a: 1}
+  _zoneImg: {fileID: 3782294193909620045}
 --- !u!222 &2452488438754748412
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Power Management/UI/ZoneConsumptionDisplay.prefab
+++ b/Assets/Prefabs/Power Management/UI/ZoneConsumptionDisplay.prefab
@@ -51,7 +51,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 72fdb1e65742990499c7c997d6847699, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _terminal: {fileID: 0}
   _zone: {fileID: 0}
   _textDisplay: {fileID: 6958928265487061089}
 --- !u!1 &840220476737905607
@@ -125,13 +124,13 @@ MonoBehaviour:
     ##'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: -4051557978932148920, guid: 50e941707bd201f4db2dbeb8b07d86a5, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
+    rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3

--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -123,6 +123,7 @@ public class AudioManager : MonoBehaviour
     private AudioClip _queueTrack = null;
     private AudioClip _currTrack = null;
     private bool _isPaused = false;
+    private bool _isAudioLogPlaying = false;
 
     float _prevTime = 0f;
 
@@ -154,7 +155,7 @@ public class AudioManager : MonoBehaviour
         else if (_currTrack is not null)
         {
             // move towards 25% configured volume during pause
-            if (_isPaused)
+            if (_isPaused || _isAudioLogPlaying)
             {
                 if (_musicSource.volume > GameManager.GetMusicVolume() / 4f)
                 {
@@ -225,10 +226,21 @@ public class AudioManager : MonoBehaviour
         _isPaused = false;
     }
 
+    public void SetAudioLogPlaying()
+    {
+        _isAudioLogPlaying = true;
+    }
+
+    public void SetAudioLogNotPlaying()
+    {
+        _isAudioLogPlaying = false;
+    }
+
     private void SetPauseOnLoad(Scene scene, LoadSceneMode mode)
     {
         // ensure pause saved state properly reset between scenes for the sake of music/ambient reduction
         _isPaused = false;
+        _isAudioLogPlaying = false;
     }
     #endregion
 

--- a/Assets/Scripts/Audio/AudioSourceVolumeSetter.cs
+++ b/Assets/Scripts/Audio/AudioSourceVolumeSetter.cs
@@ -8,23 +8,48 @@ using UnityEngine;
 /// </summary>
 public class AudioSourceVolumeSetter : MonoBehaviour
 {
+    const float LERP_SPEED = 2f;
+
     [SerializeField, Tooltip("Used to control volume level of audio source.")]
     private AudioSource _audioSource;
 
     private bool _isPaused = false;
+    private float _prevTime;
 
     private void Awake()
     {
         // ensure volume can be changed, even during scene enter when timescale is 0
         // okay actually this is NOT solving the scene load sound bug but I swear it fixed it once and then not later - inconsistent?
         _audioSource.velocityUpdateMode = AudioVelocityUpdateMode.Dynamic;
+
+        // start at 0 to prevent weird sound on scene load
+        _audioSource.volume = 0f;
+
+        _prevTime = Time.realtimeSinceStartup;
     }
 
     // Update is called once per frame
     void Update()
     {
         // 25% volume while paused, otherwise 100%
-        _audioSource.volume = (_isPaused ? 0.25f : 1f) * GameManager.GetSFXVolume();
+        // smooth lerping to prevent weird sound on scene load
+        float goalVol = (_isPaused ? 0.25f : 1f) * GameManager.GetSFXVolume();
+        float newVal = _audioSource.volume;
+        if (newVal > goalVol)
+        {
+            newVal -= (Time.realtimeSinceStartup - _prevTime) * LERP_SPEED;
+            if (newVal < goalVol)
+                newVal = goalVol;
+        }
+        else if (newVal < goalVol)
+        {
+            newVal += (Time.realtimeSinceStartup - _prevTime) * LERP_SPEED;
+            if (newVal > goalVol)
+                newVal = goalVol;
+        }
+        _audioSource.volume = newVal;
+
+        _prevTime = Time.realtimeSinceStartup;
     }
 
     private void OnEnable()

--- a/Assets/Scripts/Creature/CreatureMotion.cs
+++ b/Assets/Scripts/Creature/CreatureMotion.cs
@@ -62,17 +62,9 @@ public class CreatureMotion : MonoBehaviour
             //updates creatures chase animation speed to be similar to its expected speed & trigger VFX
             _animator.SetFloat("speed", CreatureManager.Instance.CurrentSpeed);
 
-            // VFX trailing effects
-
-            // Apply to particle system force
+            // VFX trailing effects - set y force (only the backwards force since it uses local coordinates)
             var particleMotion = _motionEffect.forceOverLifetime;
-            particleMotion.enabled = true;
-
-            Vector3 force = transform.forward * angleFactor * CreatureManager.Instance.CurrentSpeed;
-
-            particleMotion.x = new ParticleSystem.MinMaxCurve(force.y * 10);
-            particleMotion.y = new ParticleSystem.MinMaxCurve(force.x * 20);
-            particleMotion.z = new ParticleSystem.MinMaxCurve(force.z * 10);
+            particleMotion.y = new ParticleSystem.MinMaxCurve(CreatureManager.Instance.CurrentSpeed * -15);
         }
 
         // ANIMATIONS -------------------

--- a/Assets/Scripts/HUD/FileTabController.cs
+++ b/Assets/Scripts/HUD/FileTabController.cs
@@ -190,6 +190,10 @@ public class FileTabController : MonoBehaviour
             _source.UnPause();
         }
 
+        if (_selectedLog.type == Log.LogType.Audio && _isLogOpen)
+            AudioManager.Instance.SetAudioLogPlaying();
+        else
+            AudioManager.Instance.SetAudioLogNotPlaying();
     }
 
     /// <summary>

--- a/Assets/Scripts/Interaction/Interactables/Anims/Terminal.meta
+++ b/Assets/Scripts/Interaction/Interactables/Anims/Terminal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d3b1c13a8b0d1c4399f6346aa9c8588
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interaction/Interactables/Anims/Terminal/Boot Screen.controller
+++ b/Assets/Scripts/Interaction/Interactables/Anims/Terminal/Boot Screen.controller
@@ -1,0 +1,130 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-3754100371432733800
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BootUp
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: b6b671a8995913e4f94e4d4c252fd3ad, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1107 &-642300274996816865
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -3754100371432733800}
+    m_Position: {x: 30, y: 270, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 2121025792772452604}
+    m_Position: {x: 30, y: 220, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -516635184421123367}
+    m_Position: {x: 30, y: 170, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -516635184421123367}
+--- !u!1102 &-516635184421123367
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 2eb7d2c77ba46f84bb321d33e18c2b9f, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Boot Screen
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -642300274996816865}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1102 &2121025792772452604
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BootDown
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: fb579417f36cb68479b95e755164d010, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 

--- a/Assets/Scripts/Interaction/Interactables/Anims/Terminal/Boot Screen.controller.meta
+++ b/Assets/Scripts/Interaction/Interactables/Anims/Terminal/Boot Screen.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bd42a20986220c648b55a1aadc7e4a8a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interaction/Interactables/Anims/Terminal/BootDown.anim
+++ b/Assets/Scripts/Interaction/Interactables/Anims/Terminal/BootDown.anim
@@ -1,0 +1,191 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BootDown
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 0.016666668
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_BlocksRaycasts
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 3739863151
+      script: {fileID: 0}
+      typeID: 225
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 0
+      attribute: 1574349066
+      script: {fileID: 0}
+      typeID: 225
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 0.016666668
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_BlocksRaycasts
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Scripts/Interaction/Interactables/Anims/Terminal/BootDown.anim.meta
+++ b/Assets/Scripts/Interaction/Interactables/Anims/Terminal/BootDown.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb579417f36cb68479b95e755164d010
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interaction/Interactables/Anims/Terminal/BootUp.anim
+++ b/Assets/Scripts/Interaction/Interactables/Anims/Terminal/BootUp.anim
@@ -1,0 +1,227 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BootUp
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.5
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 0.5
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1.5
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_BlocksRaycasts
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 1574349066
+      script: {fileID: 0}
+      typeID: 225
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 0
+      attribute: 3739863151
+      script: {fileID: 0}
+      typeID: 225
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.5
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.5
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 0.5
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1.5
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_BlocksRaycasts
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Scripts/Interaction/Interactables/Anims/Terminal/BootUp.anim.meta
+++ b/Assets/Scripts/Interaction/Interactables/Anims/Terminal/BootUp.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6b671a8995913e4f94e4d4c252fd3ad
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interaction/Interactables/Anims/Terminal/Idle.anim
+++ b/Assets/Scripts/Interaction/Interactables/Anims/Terminal/Idle.anim
@@ -1,0 +1,104 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 1574349066
+      script: {fileID: 0}
+      typeID: 225
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Scripts/Interaction/Interactables/Anims/Terminal/Idle.anim.meta
+++ b/Assets/Scripts/Interaction/Interactables/Anims/Terminal/Idle.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2eb7d2c77ba46f84bb321d33e18c2b9f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interaction/Interactables/DoorInteractable.cs
+++ b/Assets/Scripts/Interaction/Interactables/DoorInteractable.cs
@@ -220,6 +220,13 @@ public class DoorInteractable : Interactable
         Sibling.IsOpen = IsOpen; // Make sure both doors keep the same open state
 
         yield return new WaitForSeconds(1.667f / 2);
+
+        // ensure door always snaps to end of animation, even at low frame rates
+        if (IsOpen)
+            DoorAnim.Play("Take 001", 0, 0.5f);
+        else
+            DoorAnim.Play("Take 001", 0, 1f);
+
         DoorAnim.speed = 0f;
         IsActiveDoorCoroutine = false;
         Sibling.IsActiveDoorCoroutine = false;

--- a/Assets/Scripts/Interaction/Interactables/DoorInteractable.cs
+++ b/Assets/Scripts/Interaction/Interactables/DoorInteractable.cs
@@ -33,6 +33,8 @@ public class DoorInteractable : Interactable
     private GameObject _indicatorParent;
     [SerializeField, Tooltip("Parent of E to interact")]
     private GameObject _interactPromptParent;
+    [SerializeField, Tooltip("Keycard game objects, used to disable this component of the popup separately.")]
+    private GameObject[] _keycardReqObjs;
 
     // If a door is:
     // CLOSED and BROKEN:       This is never getting opened, ever.
@@ -165,8 +167,12 @@ public class DoorInteractable : Interactable
     }
 
     // Pays attention to the graphics that help the player understand what they need for a door
-    private void IndicatorMonitor() // Problem is somewhere in here
+    private void IndicatorMonitor()
     {
+        // show keycard objects by default unless overrided to be disabled in below logic
+        foreach (GameObject obj in _keycardReqObjs)
+            obj.SetActive(true);
+
         if (RequiredKey.ToString() == "Default" || GameManager.Instance.SceneData.Keys.Contains(RequiredKey.ToString())) // If they have the key
             _requiredKeycardSprite.color = Color.green;
         else
@@ -194,7 +200,19 @@ public class DoorInteractable : Interactable
         }
         else
         {
-            _indicatorParent.SetActive(true);   // no power, so there will be an indicator
+            // only show key indicator if it actually needs a key other than default
+            if (RequiredKey.ToString() == "Default")
+            {
+                foreach (GameObject obj in _keycardReqObjs)
+                    obj.SetActive(false);
+            }
+            else
+            {
+                foreach (GameObject obj in _keycardReqObjs)
+                    obj.SetActive(true);
+            }
+
+            _indicatorParent.SetActive(true); // must show for elec requirement to be visible
             _interactPromptParent.SetActive(false); // no longer able to interact (power was turned off)
 
             _elecOperableSprite.color = Color.red;

--- a/Assets/Scripts/Interaction/Interactables/TerminalInteractable.cs
+++ b/Assets/Scripts/Interaction/Interactables/TerminalInteractable.cs
@@ -15,6 +15,8 @@ public class TerminalInteractable : Interactable
     private CinemachineVirtualCamera _terminalCam;
     [SerializeField, Tooltip("The camera aimed at the light puzzle")]
     private CinemachineVirtualCamera _puzzleCam;
+    [SerializeField, Tooltip("Animator for boot-up screen of terminal.")]
+    private Animator _bootUpAnim;
 
     private CinemachineVirtualCamera _mainCam;
     private bool _inUse = false;        // If player uses this terminal (to prevent constantly reactivating exit keybind)
@@ -63,6 +65,8 @@ public class TerminalInteractable : Interactable
 
                 // terminal boot SFX
                 AudioManager.Instance.PlayTerminalBoot();
+
+                _bootUpAnim.Play("BootUp");
             }
         }
     }
@@ -116,6 +120,9 @@ public class TerminalInteractable : Interactable
 
             // terminal boot SFX
             AudioManager.Instance.PlayTerminalBoot();
+
+            // fade logo into interface
+            _bootUpAnim.Play("BootUp");
         }
         else // If it isn't
         {
@@ -161,6 +168,8 @@ public class TerminalInteractable : Interactable
 
         // terminal close SFX
         AudioManager.Instance.PlayTerminalClose();
+
+        _bootUpAnim.Play("BootDown");
 
         yield return new WaitForEndOfFrame();
         GameManager.Instance.PlayerEnabled = true;      // Free the player

--- a/Assets/Scripts/Player/FlashlightController.cs
+++ b/Assets/Scripts/Player/FlashlightController.cs
@@ -41,6 +41,8 @@ public class FlashlightController : MonoBehaviour
     private float _defaultLightRange;
     private float _defaultSpotAngle;
 
+    private bool _isStunning = false;
+
     private void Awake()
     {
         _defaultLightRange = _light.range;
@@ -196,6 +198,10 @@ public class FlashlightController : MonoBehaviour
         // save pivot for next frame
         _prevPivotRot = _lightPivot.transform.rotation;
 
+        // skip stun burst processing if actively stun bursting
+        if (_isStunning)
+            return;
+
         // check for stun burst
         if (_isHeld)    // no longer requires light to be on for charging to start
         {
@@ -208,6 +214,7 @@ public class FlashlightController : MonoBehaviour
 
                 _light.range = _stunLightRange;
                 _light.spotAngle = _stunSpotAngle;
+                _isStunning = true;
 
                 _stunTrigger.enabled = true;
 
@@ -247,6 +254,7 @@ public class FlashlightController : MonoBehaviour
         _light.range = _defaultLightRange;
         _light.spotAngle = _defaultSpotAngle;
         _stunTrigger.enabled = false;
+        _isStunning = false;
 
         GameManager.StunHoldRatio = 0f; // return hold value back to 0 - stun is over
     }

--- a/Assets/Scripts/Player/FlashlightController.cs
+++ b/Assets/Scripts/Player/FlashlightController.cs
@@ -113,6 +113,7 @@ public class FlashlightController : MonoBehaviour
         if (_heldTimer > _stunHoldDuration || !_isHeld || _stunTrigger.enabled)
         {
             _isHeld = false;    // ensure stun doesn't go off twice - edge case
+            _stunHoldRatio = 0f;
 
             // cancel charging stun SFX
             AudioManager.Instance.StopChargeStunSFX();
@@ -163,6 +164,7 @@ public class FlashlightController : MonoBehaviour
         if (!GameManager.Instance.PlayerEnabled)
         {
             _stunHoldRatio = 0f;
+            GameManager.StunHoldRatio = 0f;
             _isHeld = false; // ensures proper cancelling of below logic for terminals / wire boxes / scene transitions
             AudioManager.Instance.StopChargeStunSFX();  // prevent chargins SFX from continuing to play
         }
@@ -206,7 +208,12 @@ public class FlashlightController : MonoBehaviour
 
         // skip stun burst processing if actively stun bursting
         if (_isStunning)
+        {
+            // max charge level while stunning
+            GameManager.StunHoldRatio = 1f;
+
             return;
+        }
 
         // check for stun burst
         if (_isHeld)    // no longer requires light to be on for charging to start

--- a/Assets/Scripts/Player/FlashlightController.cs
+++ b/Assets/Scripts/Player/FlashlightController.cs
@@ -159,7 +159,11 @@ public class FlashlightController : MonoBehaviour
     {
         // ensure hold ratio resets upon opening a box/terminal
         if (!GameManager.Instance.PlayerEnabled)
+        {
             GameManager.StunHoldRatio = 0f;
+            _isHeld = false; // ensures proper cancelling of below logic for terminals / wire boxes / scene transitions
+            AudioManager.Instance.StopChargeStunSFX();  // prevent chargins SFX from continuing to play
+        }
 
         // decrease battery charge
         if (_isOn)

--- a/Assets/Scripts/Player/FlashlightController.cs
+++ b/Assets/Scripts/Player/FlashlightController.cs
@@ -161,7 +161,7 @@ public class FlashlightController : MonoBehaviour
     void Update()
     {
         // ensure hold ratio resets upon opening a box/terminal
-        if (!GameManager.Instance.PlayerEnabled)
+        if (!GameManager.Instance.PlayerEnabled && GameManager.Instance.SceneData.IntroCutsceneWatched)
         {
             _stunHoldRatio = 0f;
             GameManager.StunHoldRatio = 0f;

--- a/Assets/Scripts/PowerManagement/PowerSystem.cs
+++ b/Assets/Scripts/PowerManagement/PowerSystem.cs
@@ -28,6 +28,13 @@ public class PowerSystem : MonoBehaviour
     [Tooltip("Ordered list of powered zones, used to access power data.")]
     public PoweredZone[] PoweredZones;
 
+    [Header("Overload Sequence")]
+    [SerializeField, Tooltip("Duration of the locked button flashing sequence.")]
+    private float _overloadDuration;
+
+    [HideInInspector]
+    public bool OverloadLock = false; // whether buttons should be locked right now
+
     private void Awake()
     {
         // give all lights a chance to configure their data and power states properly, even if they will be disabled
@@ -126,5 +133,18 @@ public class PowerSystem : MonoBehaviour
             foreach (PoweredZone zone in PoweredZones)
                 zone.UpdatePowerStates();
         }
+
+        StartCoroutine(DoShutdownLock());
+    }
+
+    private IEnumerator DoShutdownLock()
+    {
+        // lock terminal controls
+        OverloadLock = true;
+
+        yield return new WaitForSeconds(_overloadDuration);
+
+        // end flashing and return control to buttons
+        OverloadLock = false;
     }
 }

--- a/Assets/Scripts/PowerManagement/UI - Terminal/ConsumptionDisplay.cs
+++ b/Assets/Scripts/PowerManagement/UI - Terminal/ConsumptionDisplay.cs
@@ -9,8 +9,6 @@ using TMPro;
 public class ConsumptionDisplay : MonoBehaviour
 {
     [Header("Data Retrieval")]
-    [SerializeField, Tooltip("Used to retrieve the power system and read data.")]
-    private TerminalConfiguration _terminal;
     [SerializeField, Tooltip("Used to determine the index of the current zone without duplicate inspector fields.")]
     TerminalZoneToggle _zone;
 
@@ -25,7 +23,7 @@ public class ConsumptionDisplay : MonoBehaviour
     void Start()
     {
         // retrieve power zone
-        _poweredZone = _terminal.PowerSystem.PoweredZones[_zone.ZoneIndex];
+        _poweredZone = _zone.Terminal.PowerSystem.PoweredZones[_zone.ZoneIndex];
 
         UpdateDisplay();
 

--- a/Assets/Scripts/PowerManagement/UI - Terminal/TerminalZoneToggle.cs
+++ b/Assets/Scripts/PowerManagement/UI - Terminal/TerminalZoneToggle.cs
@@ -148,6 +148,6 @@ public class TerminalZoneToggle : MonoBehaviour
 
     public void HideZoneName()
     {
-        _zoneNameText.text = "";
+        _zoneNameText.text = "[None]";
     }
 }

--- a/Assets/Scripts/PowerManagement/UI - Terminal/TerminalZoneToggle.cs
+++ b/Assets/Scripts/PowerManagement/UI - Terminal/TerminalZoneToggle.cs
@@ -17,7 +17,7 @@ public class TerminalZoneToggle : MonoBehaviour
 
     [Header("References")]
     [SerializeField, Tooltip("Used to actually call the functional toggle of powered elements on the power system prefab instance.")]
-    private TerminalConfiguration _terminal;
+    public TerminalConfiguration Terminal;
     [SerializeField, Tooltip("Used to read the state of the toggle.")]
     private Toggle _toggle;
     [SerializeField, Tooltip("Enabled to indicate locked state.")]
@@ -36,7 +36,7 @@ public class TerminalZoneToggle : MonoBehaviour
 
     private void Awake()
     {
-        _powerSystem = _terminal.PowerSystem;
+        _powerSystem = Terminal.PowerSystem;
 
         // Precondition: zone index must be valid
         if (ZoneIndex < 0 || ZoneIndex >= GameManager.Instance.SceneData.PoweredZones.Length || ZoneIndex >= GameManager.Instance.SceneData.TerminalUnlocks.Length)

--- a/Assets/Scripts/PowerManagement/UI - Terminal/TerminalZoneToggle.cs
+++ b/Assets/Scripts/PowerManagement/UI - Terminal/TerminalZoneToggle.cs
@@ -59,6 +59,13 @@ public class TerminalZoneToggle : MonoBehaviour
         UpdateLockedState();
     }
 
+    private void OnEnable()
+    {
+        // ensures graphic aligns with actual state BEFORE rendering - a funny fix for it but I think it works
+        // i.e. avoids briefly seeing red from other page's zone overloading upon switching to new floor in terminal
+        Update();
+    }
+
     // Update is called once per frame
     void Update()
     {

--- a/Assets/Scripts/PowerManagement/UI - Terminal/TerminalZoneToggle.cs
+++ b/Assets/Scripts/PowerManagement/UI - Terminal/TerminalZoneToggle.cs
@@ -32,6 +32,16 @@ public class TerminalZoneToggle : MonoBehaviour
     [SerializeField, Tooltip("Bar between said numbers")]
     private GameObject _consumptionDisplayBar;
 
+    [Header("Overload Flashing")]
+    [SerializeField, Tooltip("Interval at which image flashes during overload sequence.")]
+    private float _flashingInterval;
+    [SerializeField, Tooltip("Color to which the image flashes while overloading.")]
+    private Color _flashingColor;
+    [SerializeField, Tooltip("Image component for changing color component.")]
+    private Image _zoneImg;
+
+    private Color _initImgColor;
+
     private PowerSystem _powerSystem;
 
     private void Awake()
@@ -41,6 +51,8 @@ public class TerminalZoneToggle : MonoBehaviour
         // Precondition: zone index must be valid
         if (ZoneIndex < 0 || ZoneIndex >= GameManager.Instance.SceneData.PoweredZones.Length || ZoneIndex >= GameManager.Instance.SceneData.TerminalUnlocks.Length)
             throw new System.Exception("Invalid zone index: toggle MUST be in range of Game Manager's powered zones list.");
+
+        _initImgColor = _zoneImg.color;
 
         // initial configuration
         UpdatePoweredState();
@@ -54,9 +66,32 @@ public class TerminalZoneToggle : MonoBehaviour
         if (_toggle.isOn != GameManager.Instance.SceneData.PoweredZones[ZoneIndex])
             UpdatePoweredState();
 
-        // update toggle interactability
-        if (_toggle.interactable != GameManager.Instance.SceneData.TerminalUnlocks[ZoneIndex])
-            UpdateLockedState();
+        // overload flashing
+        if (_powerSystem.OverloadLock)
+        {
+            _toggle.interactable = false;
+
+            // flash color
+            if ((int) (Time.timeSinceLevelLoad / _flashingInterval) % 2 == 1)
+            {
+                _zoneImg.color = _flashingColor;
+            }
+            // default color
+            else
+            {
+                _zoneImg.color = _initImgColor;
+            }
+        }
+        // standard button behavior
+        else
+        {
+            // ensure always solid default color in default state
+            _zoneImg.color = _initImgColor;
+
+            // update toggle interactability
+            if (_toggle.interactable != GameManager.Instance.SceneData.TerminalUnlocks[ZoneIndex])
+                UpdateLockedState();
+        }
     }
 
     /// <summary>
@@ -92,12 +127,6 @@ public class TerminalZoneToggle : MonoBehaviour
     {
         _toggle.interactable = GameManager.Instance.SceneData.TerminalUnlocks[ZoneIndex];
         _lockedIndicator.SetActive(!_toggle.interactable);
-
-/*        if (!_lockedIndicator.activeSelf)
-        {
-            _consumptionDisplayText.color = Color.white;
-            _consumptionDisplayBar.GetComponent<Image>().color = Color.white; 
-        }*/
     }
 
     /// <summary>


### PR DESCRIPTION
# Touch Ups - PR
I grabbed all the stuff I could easily do in this 3-ish day period, all over the place and in scenes a little as was possible before the rest of you jumped in. Should be a relatively quick review as its almost all :bug:bug fixes with a few :sparkles: features.
## Terminal
- :sparkles:Added boot-up screen while terminal is closed (fades in/out on interactions)
- :sparkles:Upon exceeding grid capacity, all unlocked regions now flash red and are unusable until the alarm SFX stops
- Zone toggle images no longer out of sync for first frame of opening new terminal floor page (brief flicker of incorrect state)
- Changed "Administration" region name to "Admin"
- Changed "Grid Capacity" label to "Power Usage"
- Area name now displays "[None]" instead of nothing when not hovering over a region
- Cleaned up Terminal & Terminal Interface prefab overrides properly
  - For the future, any changes to the Terminal's interface should not be made within the Terminal, but the contained interface prefab
## Door
- Now fully closes always, even at low frame rate
- Now hides keycard requirement if access level is default (only shows electricity requirement)
## Flashlight
- No longer able to start preparing a new stun charge until the previous stun blast has completed
- Stun charging now properly cancels during scene transition
- Flashlight stun charging UI (HUD)
  - :sparkles:added backer sprite so you can see max level more easily
  - :sparkles:HUD meter now only displays functional holding level between 25% and 100% (to prevent quick meter flicker when simply turning light on or off
  - HUD meter no longer gets visually stuck at max when releasing RMB right before stun would have happened
## File Tab
- :sparkles:added backer images for text, audio, and image logs (adjusting formatting slightly as necessary)
## Creature
- trailing particles now behave consistently
  - :sparkles:additionally, I made them now always go forwards, instead of the previously intended backwards
  - backwards was almost never noticeable in game. Additionally, towards player makes it feel like it is trying to really catch you (and it can warn you while running away and looking away that the creature is right behind you hehe)
## Audio
- :sparkles:ambient/music audio now reduced to 25% while listening to an audio log
- spatial audio sounds (e.g. Geothermal generator) no longer play different sounding or jarring sounds during level load
## Floor 1 & 2
- Replaced broken door instances with broken door prefab (rather than configuring on load) - this allows the doors to exist at bake-time for lighting sake
  - Floor 1: Engineering / Engineering Hall
  - Floor 2: Farm / Farm Hall
- leaning cart in farm hall given custom collider (to prevent player sliding up it)